### PR TITLE
feat: add light and dark themes and implement theme switch (auto system included)

### DIFF
--- a/src/app/(es)/layout.tsx
+++ b/src/app/(es)/layout.tsx
@@ -1,7 +1,9 @@
 import "../../styles/globals.css";
+
 import { Suspense, type ReactNode } from "react";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
+
 import { localeLabels, DEFAULT_LOCALE, isLocale } from "../../i18n/config";
 import { GoogleAnalyticsScripts } from "../../components/analytics/GoogleAnalyticsScripts";
 import { GaPageViewTracker } from "../../components/analytics/GaPageViewTracker";
@@ -13,8 +15,12 @@ import FotoLinceBanner from "../../components/FotoLinceBanner";
 import { LocaleProvider } from "../../i18n/LocaleProvider";
 import { SchemaOrg } from "../../components/SchemaOrg";
 import { BreadcrumbSchema } from "../../components/seo/BreadcrumbSchema";
-
-import { METADATA_BASE, SHARED_ICONS, SHARED_OPEN_GRAPH } from "../../lib/metadata-shared";
+import ThemeScript from "../../components/ThemeScript";
+import {
+  METADATA_BASE,
+  SHARED_ICONS,
+  SHARED_OPEN_GRAPH,
+} from "../../lib/metadata-shared";
 
 export const metadata = {
   metadataBase: METADATA_BASE,
@@ -27,20 +33,20 @@ export const metadata = {
   alternates: {
     canonical: "https://pdflince.com",
     languages: {
-      'es-ES': 'https://pdflince.com',
-      'es-MX': 'https://pdflince.com',
-      'es-CO': 'https://pdflince.com',
-      'es-AR': 'https://pdflince.com',
-      'es': 'https://pdflince.com',
-      'en': 'https://pdflince.com/en',
-      'en-US': 'https://pdflince.com/en',
-      'pt': 'https://pdflince.com/pt',
-      'pt-BR': 'https://pdflince.com/pt',
-      'de': 'https://pdflince.com/de',
-      'de-DE': 'https://pdflince.com/de',
-      'it': 'https://pdflince.com/it',
-      'it-IT': 'https://pdflince.com/it',
-      'x-default': 'https://pdflince.com',
+      "es-ES": "https://pdflince.com",
+      "es-MX": "https://pdflince.com",
+      "es-CO": "https://pdflince.com",
+      "es-AR": "https://pdflince.com",
+      es: "https://pdflince.com",
+      en: "https://pdflince.com/en",
+      "en-US": "https://pdflince.com/en",
+      pt: "https://pdflince.com/pt",
+      "pt-BR": "https://pdflince.com/pt",
+      de: "https://pdflince.com/de",
+      "de-DE": "https://pdflince.com/de",
+      it: "https://pdflince.com/it",
+      "it-IT": "https://pdflince.com/it",
+      "x-default": "https://pdflince.com",
     },
   },
   openGraph: {
@@ -63,23 +69,29 @@ export default async function RootLayout({
 }) {
   const resolvedParams = await params;
   const requestedLocale = resolvedParams?.locale;
-  const locale = requestedLocale && isLocale(requestedLocale) ? requestedLocale : DEFAULT_LOCALE;
+
+  const locale =
+    requestedLocale && isLocale(requestedLocale) ? requestedLocale : DEFAULT_LOCALE;
+
   const htmlLang = localeLabels[locale].htmlLang;
 
   return (
-    <html lang={htmlLang}>
+    <html lang={htmlLang} suppressHydrationWarning>
       <head>
-        {/* Reserved for future head customizations */}
         <GoogleAnalyticsScripts />
         <SchemaOrg />
         <BreadcrumbSchema />
+        <ThemeScript />
       </head>
+
       <body className={`font-sans ${GeistSans.variable} ${GeistMono.variable}`}>
         <LocaleProvider locale={locale}>
           <WebVitalsReporter />
+
           <Suspense fallback={null}>
             <GaPageViewTracker />
           </Suspense>
+
           <NavMenu />
           <main>{children}</main>
           <FotoLinceBanner />

--- a/src/app/de/layout.tsx
+++ b/src/app/de/layout.tsx
@@ -1,7 +1,9 @@
 import "../../styles/globals.css";
+
 import { Suspense, type ReactNode } from "react";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
+
 import NavMenu from "../../components/NavMenu";
 import Footer from "../../components/Footer";
 import FotoLinceBanner from "../../components/FotoLinceBanner";
@@ -11,39 +13,45 @@ import { GaPageViewTracker } from "../../components/analytics/GaPageViewTracker"
 import { WebVitalsReporter } from "../../components/analytics/WebVitalsReporter";
 import CookieBanner from "../../components/CookieBanner";
 import { SchemaOrg } from "../../components/SchemaOrg";
-
-import { METADATA_BASE, SHARED_ICONS, SHARED_OPEN_GRAPH } from "../../lib/metadata-shared";
+import ThemeScript from "../../components/ThemeScript";
+import {
+  METADATA_BASE,
+  SHARED_ICONS,
+  SHARED_OPEN_GRAPH,
+} from "../../lib/metadata-shared";
 
 const LOCALE = "de" as const;
 
 export const metadata = {
   metadataBase: METADATA_BASE,
   title: "PDFLince - PDFs zusammenführen, komprimieren, teilen und konvertieren",
-  description: "Kostenlose Online-PDF-Tools zum Zusammenführen, Komprimieren, Teilen, Extrahieren und Konvertieren von PDFs. 100% privat, lokale Verarbeitung in Ihrem Browser.",
+  description:
+    "Kostenlose Online-PDF-Tools zum Zusammenführen, Komprimieren, Teilen, Extrahieren und Konvertieren von PDFs. 100% privat, lokale Verarbeitung in Ihrem Browser.",
   icons: SHARED_ICONS,
   alternates: {
     canonical: "https://pdflince.com/de",
     languages: {
-      'es-ES': 'https://pdflince.com',
-      'es-MX': 'https://pdflince.com',
-      'es-CO': 'https://pdflince.com',
-      'es-AR': 'https://pdflince.com',
-      'es': 'https://pdflince.com',
-      'en': 'https://pdflince.com/en',
-      'en-US': 'https://pdflince.com/en',
-      'pt': 'https://pdflince.com/pt',
-      'pt-BR': 'https://pdflince.com/pt',
-      'de': 'https://pdflince.com/de',
-      'de-DE': 'https://pdflince.com/de',
-      'it': 'https://pdflince.com/it',
-      'it-IT': 'https://pdflince.com/it',
-      'x-default': 'https://pdflince.com',
+      "es-ES": "https://pdflince.com",
+      "es-MX": "https://pdflince.com",
+      "es-CO": "https://pdflince.com",
+      "es-AR": "https://pdflince.com",
+      es: "https://pdflince.com",
+      en: "https://pdflince.com/en",
+      "en-US": "https://pdflince.com/en",
+      pt: "https://pdflince.com/pt",
+      "pt-BR": "https://pdflince.com/pt",
+      de: "https://pdflince.com/de",
+      "de-DE": "https://pdflince.com/de",
+      it: "https://pdflince.com/it",
+      "it-IT": "https://pdflince.com/it",
+      "x-default": "https://pdflince.com",
     },
   },
   openGraph: {
     ...SHARED_OPEN_GRAPH,
     title: "PDFLince - Kostenlose und private PDF-Tools in Ihrem Browser",
-    description: "PDFs zusammenführen, komprimieren, teilen und konvertieren, ohne Dateien hochzuladen. Sichere und 100% private Verarbeitung.",
+    description:
+      "PDFs zusammenführen, komprimieren, teilen und konvertieren, ohne Dateien hochzuladen. Sichere und 100% private Verarbeitung.",
     url: "https://pdflince.com/de",
     locale: "de_DE",
     type: "website",
@@ -52,17 +60,21 @@ export const metadata = {
 
 export default function DeLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang={LOCALE}>
+    <html lang={LOCALE} suppressHydrationWarning>
       <head>
         <GoogleAnalyticsScripts />
         <SchemaOrg />
+        <ThemeScript />
       </head>
+
       <body className={`font-sans ${GeistSans.variable} ${GeistMono.variable}`}>
         <LocaleProvider locale={LOCALE}>
           <WebVitalsReporter />
+
           <Suspense fallback={null}>
             <GaPageViewTracker />
           </Suspense>
+
           <NavMenu />
           <main>{children}</main>
           <FotoLinceBanner />

--- a/src/app/en/layout.tsx
+++ b/src/app/en/layout.tsx
@@ -1,7 +1,9 @@
 import "../../styles/globals.css";
+
 import { Suspense, type ReactNode } from "react";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
+
 import NavMenu from "../../components/NavMenu";
 import Footer from "../../components/Footer";
 import FotoLinceBanner from "../../components/FotoLinceBanner";
@@ -11,39 +13,45 @@ import { GaPageViewTracker } from "../../components/analytics/GaPageViewTracker"
 import { WebVitalsReporter } from "../../components/analytics/WebVitalsReporter";
 import CookieBanner from "../../components/CookieBanner";
 import { SchemaOrg } from "../../components/SchemaOrg";
-
-import { METADATA_BASE, SHARED_ICONS, SHARED_OPEN_GRAPH } from "../../lib/metadata-shared";
+import ThemeScript from "../../components/ThemeScript";
+import {
+  METADATA_BASE,
+  SHARED_ICONS,
+  SHARED_OPEN_GRAPH,
+} from "../../lib/metadata-shared";
 
 const LOCALE = "en" as const;
 
 export const metadata = {
   metadataBase: METADATA_BASE,
   title: "PDFLince - Merge, Compress, Split, and Convert PDFs Online",
-  description: "Free online PDF tools to merge, compress, split, extract, and convert PDFs. 100% private, local processing in your browser.",
+  description:
+    "Free online PDF tools to merge, compress, split, extract, and convert PDFs. 100% private, local processing in your browser.",
   icons: SHARED_ICONS,
   alternates: {
     canonical: "https://pdflince.com/en",
     languages: {
-      'es-ES': 'https://pdflince.com',
-      'es-MX': 'https://pdflince.com',
-      'es-CO': 'https://pdflince.com',
-      'es-AR': 'https://pdflince.com',
-      'es': 'https://pdflince.com',
-      'en': 'https://pdflince.com/en',
-      'en-US': 'https://pdflince.com/en',
-      'pt': 'https://pdflince.com/pt',
-      'pt-BR': 'https://pdflince.com/pt',
-      'de': 'https://pdflince.com/de',
-      'de-DE': 'https://pdflince.com/de',
-      'it': 'https://pdflince.com/it',
-      'it-IT': 'https://pdflince.com/it',
-      'x-default': 'https://pdflince.com',
+      "es-ES": "https://pdflince.com",
+      "es-MX": "https://pdflince.com",
+      "es-CO": "https://pdflince.com",
+      "es-AR": "https://pdflince.com",
+      es: "https://pdflince.com",
+      en: "https://pdflince.com/en",
+      "en-US": "https://pdflince.com/en",
+      pt: "https://pdflince.com/pt",
+      "pt-BR": "https://pdflince.com/pt",
+      de: "https://pdflince.com/de",
+      "de-DE": "https://pdflince.com/de",
+      it: "https://pdflince.com/it",
+      "it-IT": "https://pdflince.com/it",
+      "x-default": "https://pdflince.com",
     },
   },
   openGraph: {
     ...SHARED_OPEN_GRAPH,
     title: "PDFLince - Free and Private PDF Tools in Your Browser",
-    description: "Merge, compress, split, and convert PDFs without uploading files. Secure and 100% private processing.",
+    description:
+      "Merge, compress, split, and convert PDFs without uploading files. Secure and 100% private processing.",
     url: "https://pdflince.com/en",
     locale: "en_US",
     type: "website",
@@ -52,17 +60,21 @@ export const metadata = {
 
 export default function EnLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang={LOCALE}>
+    <html lang={LOCALE} suppressHydrationWarning>
       <head>
         <GoogleAnalyticsScripts />
         <SchemaOrg />
+        <ThemeScript />
       </head>
+
       <body className={`font-sans ${GeistSans.variable} ${GeistMono.variable}`}>
         <LocaleProvider locale={LOCALE}>
           <WebVitalsReporter />
+
           <Suspense fallback={null}>
             <GaPageViewTracker />
           </Suspense>
+
           <NavMenu />
           <main>{children}</main>
           <FotoLinceBanner />

--- a/src/app/it/layout.tsx
+++ b/src/app/it/layout.tsx
@@ -1,7 +1,9 @@
 import "../../styles/globals.css";
+
 import { Suspense, type ReactNode } from "react";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
+
 import NavMenu from "../../components/NavMenu";
 import Footer from "../../components/Footer";
 import FotoLinceBanner from "../../components/FotoLinceBanner";
@@ -11,39 +13,45 @@ import { GaPageViewTracker } from "../../components/analytics/GaPageViewTracker"
 import { WebVitalsReporter } from "../../components/analytics/WebVitalsReporter";
 import CookieBanner from "../../components/CookieBanner";
 import { SchemaOrg } from "../../components/SchemaOrg";
-
-import { METADATA_BASE, SHARED_ICONS, SHARED_OPEN_GRAPH } from "../../lib/metadata-shared";
+import ThemeScript from "../../components/ThemeScript";
+import {
+  METADATA_BASE,
+  SHARED_ICONS,
+  SHARED_OPEN_GRAPH,
+} from "../../lib/metadata-shared";
 
 const LOCALE = "it" as const;
 
 export const metadata = {
   metadataBase: METADATA_BASE,
   title: "PDFLince - Merge, Compress, Split, and Convert PDFs Online",
-  description: "Free online PDF tools to merge, compress, split, extract, and convert PDFs. 100% private, local processing in your browser.",
+  description:
+    "Free online PDF tools to merge, compress, split, extract, and convert PDFs. 100% private, local processing in your browser.",
   icons: SHARED_ICONS,
   alternates: {
     canonical: "https://pdflince.com/en",
     languages: {
-      'es-ES': 'https://pdflince.com',
-      'es-MX': 'https://pdflince.com',
-      'es-CO': 'https://pdflince.com',
-      'es-AR': 'https://pdflince.com',
-      'es': 'https://pdflince.com',
-      'en': 'https://pdflince.com/en',
-      'en-US': 'https://pdflince.com/en',
-      'pt': 'https://pdflince.com/pt',
-      'pt-BR': 'https://pdflince.com/pt',
-      'de': 'https://pdflince.com/de',
-      'de-DE': 'https://pdflince.com/de',
-      'it': 'https://pdflince.com/it',
-      'it-IT': 'https://pdflince.com/it',
-      'x-default': 'https://pdflince.com',
+      "es-ES": "https://pdflince.com",
+      "es-MX": "https://pdflince.com",
+      "es-CO": "https://pdflince.com",
+      "es-AR": "https://pdflince.com",
+      es: "https://pdflince.com",
+      en: "https://pdflince.com/en",
+      "en-US": "https://pdflince.com/en",
+      pt: "https://pdflince.com/pt",
+      "pt-BR": "https://pdflince.com/pt",
+      de: "https://pdflince.com/de",
+      "de-DE": "https://pdflince.com/de",
+      it: "https://pdflince.com/it",
+      "it-IT": "https://pdflince.com/it",
+      "x-default": "https://pdflince.com",
     },
   },
   openGraph: {
     ...SHARED_OPEN_GRAPH,
     title: "PDFLince - Strumenti PDF gratuiti e privati nel tuo browser",
-    description: "Unisci, comprimi, dividi e converti PDF senza dover caricare i file online. Elaborazione sicura e completamente privata.",
+    description:
+      "Unisci, comprimi, dividi e converti PDF senza dover caricare i file online. Elaborazione sicura e completamente privata.",
     url: "https://pdflince.com/it",
     locale: "it_IT",
     type: "website",
@@ -52,17 +60,21 @@ export const metadata = {
 
 export default function ItLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang={LOCALE}>
+    <html lang={LOCALE} suppressHydrationWarning>
       <head>
         <GoogleAnalyticsScripts />
         <SchemaOrg />
+        <ThemeScript />
       </head>
+
       <body className={`font-sans ${GeistSans.variable} ${GeistMono.variable}`}>
         <LocaleProvider locale={LOCALE}>
           <WebVitalsReporter />
+
           <Suspense fallback={null}>
             <GaPageViewTracker />
           </Suspense>
+
           <NavMenu />
           <main>{children}</main>
           <FotoLinceBanner />

--- a/src/app/pt/layout.tsx
+++ b/src/app/pt/layout.tsx
@@ -1,7 +1,9 @@
 import "../../styles/globals.css";
+
 import { Suspense, type ReactNode } from "react";
 import { GeistSans } from "geist/font/sans";
 import { GeistMono } from "geist/font/mono";
+
 import NavMenu from "../../components/NavMenu";
 import Footer from "../../components/Footer";
 import FotoLinceBanner from "../../components/FotoLinceBanner";
@@ -11,37 +13,45 @@ import { GaPageViewTracker } from "../../components/analytics/GaPageViewTracker"
 import { WebVitalsReporter } from "../../components/analytics/WebVitalsReporter";
 import CookieBanner from "../../components/CookieBanner";
 import { SchemaOrg } from "../../components/SchemaOrg";
-
-import { METADATA_BASE, SHARED_ICONS, SHARED_OPEN_GRAPH } from "../../lib/metadata-shared";
+import ThemeScript from "../../components/ThemeScript";
+import {
+  METADATA_BASE,
+  SHARED_ICONS,
+  SHARED_OPEN_GRAPH,
+} from "../../lib/metadata-shared";
 
 const LOCALE = "pt" as const;
 
 export const metadata = {
   metadataBase: METADATA_BASE,
   title: "PDFLince - Juntar, Comprimir, Dividir e Converter PDFs Online",
-  description: "Ferramentas de PDF online gratuitas para juntar, comprimir, dividir, extrair e converter PDFs. 100% privado, processamento local no seu navegador.",
+  description:
+    "Ferramentas de PDF online gratuitas para juntar, comprimir, dividir, extrair e converter PDFs. 100% privado, processamento local no seu navegador.",
   icons: SHARED_ICONS,
   alternates: {
     canonical: "https://pdflince.com/pt",
     languages: {
-      'es-ES': 'https://pdflince.com',
-      'es-MX': 'https://pdflince.com',
-      'es-CO': 'https://pdflince.com',
-      'es-AR': 'https://pdflince.com',
-      'es': 'https://pdflince.com',
-      'en': 'https://pdflince.com/en',
-      'en-US': 'https://pdflince.com/en',
-      'pt': 'https://pdflince.com/pt',
-      'pt-BR': 'https://pdflince.com/pt',
-      'de': 'https://pdflince.com/de',
-      'de-DE': 'https://pdflince.com/de',
-      'x-default': 'https://pdflince.com',
+      "es-ES": "https://pdflince.com",
+      "es-MX": "https://pdflince.com",
+      "es-CO": "https://pdflince.com",
+      "es-AR": "https://pdflince.com",
+      es: "https://pdflince.com",
+      en: "https://pdflince.com/en",
+      "en-US": "https://pdflince.com/en",
+      pt: "https://pdflince.com/pt",
+      "pt-BR": "https://pdflince.com/pt",
+      de: "https://pdflince.com/de",
+      "de-DE": "https://pdflince.com/de",
+      it: "https://pdflince.com/it",
+      "it-IT": "https://pdflince.com/it",
+      "x-default": "https://pdflince.com",
     },
   },
   openGraph: {
     ...SHARED_OPEN_GRAPH,
     title: "PDFLince - Ferramentas de PDF gratuitas e privadas no seu navegador",
-    description: "Combine, comprima, divida e converta PDFs sem carregar arquivos. Processamento seguro e 100% privado.",
+    description:
+      "Combine, comprima, divida e converta PDFs sem carregar arquivos. Processamento seguro e 100% privado.",
     url: "https://pdflince.com/pt",
     locale: "pt_BR",
     type: "website",
@@ -50,17 +60,21 @@ export const metadata = {
 
 export default function PtLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang={LOCALE}>
+    <html lang={LOCALE} suppressHydrationWarning>
       <head>
         <GoogleAnalyticsScripts />
         <SchemaOrg />
+        <ThemeScript />
       </head>
+
       <body className={`font-sans ${GeistSans.variable} ${GeistMono.variable}`}>
         <LocaleProvider locale={LOCALE}>
           <WebVitalsReporter />
+
           <Suspense fallback={null}>
             <GaPageViewTracker />
           </Suspense>
+
           <NavMenu />
           <main>{children}</main>
           <FotoLinceBanner />

--- a/src/components/NavMenu.tsx
+++ b/src/components/NavMenu.tsx
@@ -1,17 +1,24 @@
-'use client';
+"use client";
 
-import Image from 'next/image';
-import Link from 'next/link';
-import { usePathname, useRouter } from 'next/navigation';
-import { useMemo, useState, type ChangeEvent } from 'react';
-import { useDictionary, useLocale } from '../i18n/LocaleProvider';
-import { SUPPORTED_LOCALES, localeLabels, type Locale } from '../i18n/config';
-import { getLocalizedAlternateMap, getRouteIdentifierForPath, getRoutePath } from '../i18n/routing';
+import Image from "next/image";
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { useMemo, useState, type ChangeEvent } from "react";
+
+import { useDictionary, useLocale } from "../i18n/LocaleProvider";
+import { SUPPORTED_LOCALES, localeLabels, type Locale } from "../i18n/config";
+import {
+  getLocalizedAlternateMap,
+  getRouteIdentifierForPath,
+  getRoutePath,
+} from "../i18n/routing";
+import ThemeToggle from "./ThemeToggle";
 
 export default function NavMenu() {
   const pathname = usePathname();
   const router = useRouter();
   const [isOpen, setIsOpen] = useState(false);
+
   const dictionary = useDictionary();
   const locale = useLocale();
   const { nav } = dictionary.components;
@@ -19,83 +26,120 @@ export default function NavMenu() {
 
   const isActive = (path: string) => pathname === path;
 
-  const routeIdentifier = useMemo(() => getRouteIdentifierForPath(locale, pathname), [locale, pathname]);
-
-  const languageOptions = useMemo(
-    () => {
-      const alternates = routeIdentifier ? getLocalizedAlternateMap(routeIdentifier) : null;
-      return SUPPORTED_LOCALES.map(candidateLocale => ({
-        locale: candidateLocale,
-        href: alternates?.[candidateLocale] ?? getRoutePath(candidateLocale, 'home'),
-      }));
-    },
-    [routeIdentifier]
+  const routeIdentifier = useMemo(
+    () => getRouteIdentifierForPath(locale, pathname),
+    [locale, pathname]
   );
+
+  const languageOptions = useMemo(() => {
+    const alternates = routeIdentifier ? getLocalizedAlternateMap(routeIdentifier) : null;
+
+    return SUPPORTED_LOCALES.map((candidateLocale) => ({
+      locale: candidateLocale,
+      href: alternates?.[candidateLocale] ?? getRoutePath(candidateLocale, "home"),
+    }));
+  }, [routeIdentifier]);
 
   const handleLocaleChange = (event: ChangeEvent<HTMLSelectElement>) => {
     const nextLocale = event.target.value as Locale;
-    const target = languageOptions.find(option => option.locale === nextLocale)?.href;
+    const target = languageOptions.find((option) => option.locale === nextLocale)?.href;
+
     setIsOpen(false);
-    router.push(target ?? getRoutePath(nextLocale, 'home'));
+    router.push(target ?? getRoutePath(nextLocale, "home"));
   };
 
   return (
     <nav className="w-full border-b border-[var(--ui)] bg-[var(--bg)]/90 backdrop-blur-sm">
-      <div className="container mx-auto px-4 py-4 flex flex-wrap justify-between items-center">
+      <div className="container mx-auto flex flex-wrap items-center justify-between px-4 py-4">
         <Link href={routes.home} className="flex items-center">
-          <Image src="/favicon.ico?v=2" alt="PDFLince logo" width={32} height={32} className="mr-2" unoptimized />
+          <Image
+            src="/favicon.ico?v=2"
+            alt="PDFLince logo"
+            width={32}
+            height={32}
+            className="mr-2"
+            unoptimized
+          />
           <span className="text-xl font-bold">PDFLince</span>
         </Link>
 
         <button
-          className="md:hidden p-2"
+          className="rounded-md p-2 text-[var(--tx)] transition-colors hover:bg-[var(--ui)] md:hidden"
           onClick={() => setIsOpen((open) => !open)}
           aria-label={nav.menuLabel}
         >
-          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <svg className="h-6 w-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             {isOpen ? (
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
             ) : (
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M4 6h16M4 12h16M4 18h16"
+              />
             )}
           </svg>
         </button>
 
-        <div className={`${isOpen ? 'block' : 'hidden'} md:block w-full md:w-auto mt-4 md:mt-0`}>
-          <ul className="flex flex-col md:flex-row md:items-center md:space-x-6 space-y-3 md:space-y-0">
+        <div className={`${isOpen ? "block" : "hidden"} mt-4 w-full md:mt-0 md:block md:w-auto`}>
+          <ul className="flex flex-col gap-3 md:flex-row md:items-center md:gap-0">
             <li>
               <Link
                 href={routes.home}
-                className={`${isActive(routes.home) ? 'text-[var(--accent)] font-medium' : 'text-[var(--tx-2)]'} hover:text-[var(--accent)] transition-colors`}
+                className={`transition-colors hover:text-[var(--accent)] ${
+                  isActive(routes.home)
+                    ? "font-medium text-[var(--accent)]"
+                    : "text-[var(--tx-2)]"
+                }`}
               >
                 {nav.home}
               </Link>
             </li>
-            <li>
+
+            <li className="md:ml-6">
               <Link
                 href={routes.faq}
-                className={`${isActive(routes.faq) ? 'text-[var(--accent)] font-medium' : 'text-[var(--tx-2)]'} hover:text-[var(--accent)] transition-colors`}
+                className={`transition-colors hover:text-[var(--accent)] ${
+                  isActive(routes.faq)
+                    ? "font-medium text-[var(--accent)]"
+                    : "text-[var(--tx-2)]"
+                }`}
               >
                 {nav.faq}
               </Link>
             </li>
 
-            <li className="md:ml-4">
-              <label className="sr-only" htmlFor="nav-language-select">
-                {nav.languageLabel}
-              </label>
-              <select
-                id="nav-language-select"
-                className="w-full rounded-md border border-[var(--ui)] bg-white px-3 py-2 text-sm text-[var(--tx)] shadow-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] md:w-auto"
-                value={locale}
-                onChange={handleLocaleChange}
-              >
-                {languageOptions.map(option => (
-                  <option key={option.locale} value={option.locale}>
-                    {localeLabels[option.locale].nativeName}
-                  </option>
-                ))}
-              </select>
+            <li className="hidden md:flex items-center">
+                <div className="h-5 w-px bg-black/10 dark:bg-white/10 mx-3" />
+              </li>
+
+            <li className="md:ml-6">
+              <div className="flex items-center gap-2">
+                <ThemeToggle />
+
+                <label className="sr-only" htmlFor="nav-language-select">
+                  {nav.languageLabel}
+                </label>
+
+                <select
+                  id="nav-language-select"
+                  className="w-full rounded-md border border-[var(--ui)] bg-[var(--bg)] px-3 py-2 text-sm text-[var(--tx)] shadow-sm transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] md:w-auto"
+                  value={locale}
+                  onChange={handleLocaleChange}
+                >
+                  {languageOptions.map((option) => (
+                    <option key={option.locale} value={option.locale}>
+                      {localeLabels[option.locale].nativeName}
+                    </option>
+                  ))}
+                </select>
+              </div>
             </li>
           </ul>
         </div>

--- a/src/components/ThemeScript.tsx
+++ b/src/components/ThemeScript.tsx
@@ -1,0 +1,79 @@
+// Script injected in <head> to apply the correct theme as early as possible.
+// This prevents a flash of incorrect theme before React hydration.
+
+const themeInitScript = `
+(function () {
+  const STORAGE_KEY = "theme-preference";
+
+  function getStoredTheme() {
+    try {
+      return localStorage.getItem(STORAGE_KEY) || "system";
+    } catch {
+      return "system";
+    }
+  }
+
+  function getResolvedTheme(theme) {
+    if (theme === "light" || theme === "dark") return theme;
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  }
+
+  function applyTheme(theme) {
+    const resolvedTheme = getResolvedTheme(theme);
+    const root = document.documentElement;
+
+    root.dataset.theme = theme;
+    root.dataset.resolvedTheme = resolvedTheme;
+    root.classList.toggle("dark", resolvedTheme === "dark");
+    root.style.colorScheme = resolvedTheme;
+  }
+
+  applyTheme(getStoredTheme());
+})();
+`;
+
+// Dark theme CSS variables. These override the existing design tokens when dark mode is active,
+// allowing the rest of the app to keep using the same variables.
+
+const themeVariableStyles = `
+:root.dark,
+:root[data-resolved-theme="dark"] {
+  --bg: #140d0d;
+  --bg-2: #1b1212;
+  --ui: #2a1b1b;
+  --ui-2: #3a2323;
+  --ui-3: #4a2b2b;
+
+  --tx: #fff3ef;
+  --tx-2: #f3d8d0;
+  --tx-3: #dfb7ac;
+
+  --accent: #ff7a45;
+  --accent-2: #ff5a36;
+
+  --re: #ff7f66;
+  --or: #ff8b52;
+  --gr: #3ac48b;
+  --bl: #4bb7ff;
+  --pu: #ff8fad;
+  --ma: #ff4d6d;
+
+  --btn-bg: #ff7a45;
+  --btn-border: #e65f31;
+  --btn-hover: #ff8a5c;
+  --btn-hover-border: #f06c3e;
+  --btn-active: #e85d2d;
+  --btn-active-border: #c94d21;
+  --btn-disabled: #5a3434;
+  --btn-text: #fffaf8;
+}
+`;
+
+export default function ThemeScript() {
+  return (
+    <>
+      <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      <style dangerouslySetInnerHTML={{ __html: themeVariableStyles }} />
+    </>
+  );
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useLocale } from "../i18n/LocaleProvider";
+
+type ThemePreference = "light" | "dark" | "system";
+type ResolvedTheme = "light" | "dark";
+
+const STORAGE_KEY = "theme-preference";
+const THEME_ORDER: ThemePreference[] = ["light", "dark", "system"]; // Order used to cycle themes on click
+
+const COPY = {
+  es: {
+    label: "Tema",
+    light: "Claro",
+    dark: "Oscuro",
+    system: "Sistema",
+  },
+  en: {
+    label: "Theme",
+    light: "Light",
+    dark: "Dark",
+    system: "System",
+  },
+  pt: {
+    label: "Tema",
+    light: "Claro",
+    dark: "Escuro",
+    system: "Sistema",
+  },
+  de: {
+    label: "Design",
+    light: "Hell",
+    dark: "Dunkel",
+    system: "System",
+  },
+  it: {
+    label: "Tema",
+    light: "Chiaro",
+    dark: "Scuro",
+    system: "Sistema",
+  },
+} as const;
+
+function getSystemTheme(): ResolvedTheme {
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function resolveTheme(theme: ThemePreference): ResolvedTheme {
+  return theme === "system" ? getSystemTheme() : theme;
+}
+
+function applyTheme(theme: ThemePreference) {
+  const resolvedTheme = resolveTheme(theme);
+  const root = document.documentElement;
+
+  root.dataset.theme = theme;
+  root.dataset.resolvedTheme = resolvedTheme;
+  root.classList.toggle("dark", resolvedTheme === "dark");
+  root.style.colorScheme = resolvedTheme;
+}
+
+function getStoredTheme(): ThemePreference {
+  try {
+    const value = localStorage.getItem(STORAGE_KEY);
+    if (value === "light" || value === "dark" || value === "system") {
+      return value;
+    }
+  } catch {
+    // noop
+  }
+
+  return "system";
+}
+
+function getNextTheme(theme: ThemePreference): ThemePreference {
+  const index = THEME_ORDER.indexOf(theme);
+  return THEME_ORDER[(index + 1) % THEME_ORDER.length];
+}
+
+function SunIcon({ className = "h-4 w-4" }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2.5" />
+      <path d="M12 19.5V22" />
+      <path d="M4.93 4.93l1.77 1.77" />
+      <path d="M17.3 17.3l1.77 1.77" />
+      <path d="M2 12h2.5" />
+      <path d="M19.5 12H22" />
+      <path d="M4.93 19.07l1.77-1.77" />
+      <path d="M17.3 6.7l1.77-1.77" />
+    </svg>
+  );
+}
+
+function MoonIcon({ className = "h-4 w-4" }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z" />
+    </svg>
+  );
+}
+
+function MonitorIcon({ className = "h-4 w-4" }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="3" y="4" width="18" height="12" rx="2" />
+      <path d="M8 20h8" />
+      <path d="M12 16v4" />
+    </svg>
+  );
+}
+// Selects correct icon based on current theme
+function ThemeIcon({ theme }: { theme: ThemePreference }) {
+  if (theme === "light") return <SunIcon />;
+  if (theme === "dark") return <MoonIcon />;
+  return <MonitorIcon />;
+}
+
+export default function ThemeToggle() {
+  const locale = useLocale();
+  const copy = useMemo(() => COPY[locale] ?? COPY.en, [locale]);
+
+  const [theme, setTheme] = useState<ThemePreference>("system");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const savedTheme = getStoredTheme();
+    setTheme(savedTheme);
+    applyTheme(savedTheme);
+    setMounted(true);
+    
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");     // Sync with system changes when using "system" mode
+
+    const handleSystemChange = () => {
+      const currentTheme = getStoredTheme();
+      if (currentTheme === "system") {
+        applyTheme("system");
+      }
+    };
+
+    mediaQuery.addEventListener("change", handleSystemChange);
+
+    return () => {
+      mediaQuery.removeEventListener("change", handleSystemChange);
+    };
+  }, []);
+
+  const currentLabel =
+    theme === "light" ? copy.light : theme === "dark" ? copy.dark : copy.system;
+
+  const nextTheme = getNextTheme(theme);
+  const nextLabel =
+    nextTheme === "light" ? copy.light : nextTheme === "dark" ? copy.dark : copy.system;
+
+  const handleClick = () => {
+    const updatedTheme = getNextTheme(theme);
+
+    setTheme(updatedTheme);
+
+    try {
+      localStorage.setItem(STORAGE_KEY, updatedTheme);
+    } catch {
+      // noop
+    }
+
+    applyTheme(updatedTheme);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className="group inline-flex h-9 w-9 items-center justify-center rounded-full border border-[var(--ui)] bg-[var(--bg)] text-[var(--tx)] shadow-sm transition-all
+        hover:scale-[1.05] hover:border-[var(--ui-2)] hover:bg-[var(--ui)]
+        focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]
+        active:scale-[0.96]"
+      aria-label={`${copy.label}: ${currentLabel}. Next: ${nextLabel}`}
+    >
+      <span className="inline-flex h-8 w-8 items-center justify-center rounded-full">
+        <ThemeIcon theme={theme} />
+      </span>
+    </button>
+  );
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -150,13 +150,11 @@ export default function ThemeToggle() {
   const copy = useMemo(() => COPY[locale] ?? COPY.en, [locale]);
 
   const [theme, setTheme] = useState<ThemePreference>("system");
-  const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     const savedTheme = getStoredTheme();
     setTheme(savedTheme);
     applyTheme(savedTheme);
-    setMounted(true);
     
     const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");     // Sync with system changes when using "system" mode
 

--- a/src/components/pdf-processor/ProcessingOptions.tsx
+++ b/src/components/pdf-processor/ProcessingOptions.tsx
@@ -23,6 +23,12 @@ type OptionToggleProps = {
 
 type CompressionLevel = NonNullable<PDFProcessingOptions['compressionLevel']>;
 
+const FORM_CONTROL_CLASS =
+  'w-full rounded-md border border-[var(--ui-2)] bg-white px-2 py-2 text-sm text-[var(--tx)] dark:bg-[var(--bg)] dark:text-[var(--tx)]';
+
+const FORM_CONTROL_COMPACT_CLASS =
+  'w-full rounded-md border border-[var(--ui-2)] bg-white p-2 text-[var(--tx)] dark:bg-[var(--bg)] dark:text-[var(--tx)]';
+
 const COMPRESSION_PRESETS: Record<CompressionLevel, Partial<PDFProcessingOptions>> = {
   low: {
     preserveMetadata: true,
@@ -233,7 +239,7 @@ export default function ProcessingOptions({ mode, options, onOptionsChangeAction
                 type="text"
                 value={metadataTitle}
                 onChange={event => handleMetadataChange('title', event.target.value)}
-                className="w-full rounded-md border border-[var(--ui-2)] bg-white px-2 py-2 text-sm"
+                className={FORM_CONTROL_CLASS}
               />
             </div>
             <div className="space-y-1">
@@ -245,7 +251,7 @@ export default function ProcessingOptions({ mode, options, onOptionsChangeAction
                 type="text"
                 value={metadataAuthor}
                 onChange={event => handleMetadataChange('author', event.target.value)}
-                className="w-full rounded-md border border-[var(--ui-2)] bg-white px-2 py-2 text-sm"
+                className={FORM_CONTROL_CLASS}
               />
             </div>
           </div>
@@ -267,7 +273,7 @@ export default function ProcessingOptions({ mode, options, onOptionsChangeAction
             id="split-pages-per-file"
             type="number"
             min={1}
-            className="w-full rounded-md border border-[var(--ui-2)] bg-white p-2"
+            className={FORM_CONTROL_COMPACT_CLASS}
             value={options.pagesPerFile ?? 1}
             onChange={event => update('pagesPerFile', Math.max(1, Number(event.target.value) || 1))}
           />
@@ -418,7 +424,7 @@ export default function ProcessingOptions({ mode, options, onOptionsChangeAction
               placeholder={exportStrings.baseNamePlaceholder}
               value={baseName}
               onChange={event => update('imageBaseName', event.target.value)}
-              className="mt-1 w-full rounded-md border border-[var(--ui-2)] bg-white px-2 py-2 text-sm"
+              className={`mt-1 ${FORM_CONTROL_CLASS}`}
             />
             <p className="mt-1 text-xs text-[var(--tx-3)]">{exportStrings.baseNameHint}</p>
           </div>
@@ -475,7 +481,7 @@ export default function ProcessingOptions({ mode, options, onOptionsChangeAction
           </label>
           <select
             id="page-size"
-            className="mt-1 w-full rounded-md border border-[var(--ui-2)] bg-white px-2 py-2 text-sm"
+            className={`mt-1 ${FORM_CONTROL_CLASS}`}
             value={currentSize}
             onChange={event => update('pageSize', event.target.value as PDFProcessingOptions['pageSize'])}
           >
@@ -493,7 +499,7 @@ export default function ProcessingOptions({ mode, options, onOptionsChangeAction
           </label>
           <select
             id="page-orientation"
-            className="mt-1 w-full rounded-md border border-[var(--ui-2)] bg-white px-2 py-2 text-sm"
+            className={`mt-1 ${FORM_CONTROL_CLASS}`}
             value={currentOrientation}
             onChange={event =>
               update('pageOrientation', event.target.value as PDFProcessingOptions['pageOrientation'])
@@ -519,7 +525,7 @@ export default function ProcessingOptions({ mode, options, onOptionsChangeAction
             step={6}
             value={margin}
             onChange={event => update('pageMarginPoints', Math.max(0, Number(event.target.value) || 0))}
-            className="mt-1 w-full rounded-md border border-[var(--ui-2)] bg-white px-2 py-2 text-sm"
+            className={`mt-1 ${FORM_CONTROL_CLASS}`}
           />
           <p className="text-xs text-[var(--tx-3)]">{layoutStrings.marginHint}</p>
         </div>
@@ -540,7 +546,7 @@ export default function ProcessingOptions({ mode, options, onOptionsChangeAction
               type="text"
               value={backgroundColor}
               onChange={event => update('backgroundColor', event.target.value)}
-              className="flex-1 rounded-md border border-[var(--ui-2)] bg-white px-2 py-2 text-sm"
+              className="flex-1 rounded-md border border-[var(--ui-2)] bg-white px-2 py-2 text-sm text-[var(--tx)] dark:bg-[var(--bg)] dark:text-[var(--tx)]"
             />
           </div>
           <p className="text-xs text-[var(--tx-3)]">{layoutStrings.backgroundHint}</p>

--- a/src/components/pdf-processor/index.tsx
+++ b/src/components/pdf-processor/index.tsx
@@ -1856,7 +1856,7 @@ export default function PDFProcessor({ initialMode = 'merge' }: { initialMode?: 
                         }`}
                     >
                       <header
-                        className="flex flex-wrap items-center justify-between gap-3 border-b border-[var(--ui-2)] bg-white/70 px-4 py-3 cursor-pointer"
+                        className="processor-file-panel-header flex flex-wrap items-center justify-between gap-3 border-b border-[var(--ui-2)] bg-white/70 px-4 py-3 cursor-pointer"
                         onClick={() => handleFileChange(index)}
                         role="button"
                         tabIndex={0}
@@ -1915,7 +1915,7 @@ export default function PDFProcessor({ initialMode = 'merge' }: { initialMode?: 
                         }`}
                     >
                       <header
-                        className="flex flex-wrap items-center justify-between gap-3 border-b border-[var(--ui-2)] bg-white/70 px-4 py-3 cursor-pointer"
+                        className="processor-file-panel-header flex flex-wrap items-center justify-between gap-3 border-b border-[var(--ui-2)] bg-white/70 px-4 py-3 cursor-pointer"
                         onClick={() => handleFileChange(index)}
                         role="button"
                         tabIndex={0}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -612,6 +612,11 @@ input[type="range"]::-webkit-slider-thumb:hover {
   color: var(--accent);
 }
 
+.dark .processor-file-panel-header,
+:root[data-resolved-theme="dark"] .processor-file-panel-header {
+  background-color: rgba(20, 13, 13, 0.8);
+}
+
 /* Image preview thumbnail in file list */
 .file-preview-thumbnail {
   width: 2rem;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -3,7 +3,7 @@ import { fontFamily } from "tailwindcss/defaultTheme";
 
 export default {
   content: ["./src/**/*.{js,ts,jsx,tsx}"],
-  darkMode: 'media',
+  darkMode: "class",
   theme: {
     extend: {
       fontFamily: {


### PR DESCRIPTION
## Description

This PR introduces full theme support, including light mode, dark mode, and the ability to switch between them.
It also adds an "auto" option that syncs the theme with the user's system preferences.

Nowadays, most modern websites provide users with control over their preferred theme. PDF Lince should offer the same flexibility to ensure a better and more accessible user experience.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

<img width="1890" height="945" alt="Screenshot 2026-03-30 111952" src="https://github.com/user-attachments/assets/cc297ab6-aa9e-4818-abc0-1a4b52f13175" />
<img width="1893" height="933" alt="Screenshot 2026-03-30 112000" src="https://github.com/user-attachments/assets/f6966d5e-54d4-450e-968c-504d855800cc" />
