### PR TITLE
Feat/french

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg?style=for-the-badge)](https://opensource.org/licenses/MIT)
 [![Build Status](https://github.com/GSiesto/pdflince/actions/workflows/deploy.yml/badge.svg?style=for-the-badge)](https://github.com/GSiesto/pdflince/actions)
 
-| 🇬🇧 English | 🇪🇸 Español | 🇩🇪 Deutsch | 🇵🇹 Português | 🇮🇹 Italiano |
-|:---:|:---:|:---:|:---:|:---:|
-| [pdflince.com](https://pdflince.com/en?utm_source=github&utm_medium=readme&utm_campaign=pdflince_public) | [pdflince.com](https://pdflince.com/?utm_source=github&utm_medium=readme&utm_campaign=pdflince_public) | [pdflince.com](https://pdflince.com/de?utm_source=github&utm_medium=readme&utm_campaign=pdflince_public) | [pdflince.com](https://pdflince.com/pt?utm_source=github&utm_medium=readme&utm_campaign=pdflince_public) | [pdflince.com](https://pdflince.com/it?utm_source=github&utm_medium=readme&utm_campaign=pdflince_public)
+| English | Español | Français | Deutsch | Português | Italiano |
+|:---:|:---:|:---:|:---:|:---:|:---:|
+| [pdflince.com](https://pdflince.com/en?utm_source=github&utm_medium=readme&utm_campaign=pdflince_public) | [pdflince.com](https://pdflince.com/?utm_source=github&utm_medium=readme&utm_campaign=pdflince_public) | [pdflince.com](https://pdflince.com/fr?utm_source=github&utm_medium=readme&utm_campaign=pdflince_public) | [pdflince.com](https://pdflince.com/de?utm_source=github&utm_medium=readme&utm_campaign=pdflince_public) | [pdflince.com](https://pdflince.com/pt?utm_source=github&utm_medium=readme&utm_campaign=pdflince_public) | [pdflince.com](https://pdflince.com/it?utm_source=github&utm_medium=readme&utm_campaign=pdflince_public)
 
-## 🚀 Why PDFLince?
+## Why PDFLince?
 
 Most online PDF tools require you to upload your sensitive documents to their cloud servers for processing. This creates privacy risks and compliance issues.
 
@@ -22,7 +22,7 @@ Most online PDF tools require you to upload your sensitive documents to their cl
 - **Offline Capable**: Works even without an internet connection once loaded.
 - **No File Size Limits**: Bypasses server payload limits since it uses your device's memory.
 
-## ✨ Features
+## Features
 
 - **Compress**: Smart compression with adaptive image downscaling (WebWorker-powered).
 - **Merge**: Combine multiple PDFs into one document.
@@ -32,9 +32,9 @@ Most online PDF tools require you to upload your sensitive documents to their cl
 - **Crop**: Crop PDF pages manually with visual selection or by specifying precise values
 - **Rotate**: Rotate selected pages and preview changes in real-time before exporting.
 - **Secure**: 100% local processing verifiable via Network tab.
-- **Multilingual**: Native support for English, Spanish, German, Portuguese, Italian.
+- **Multilingual**: Native support for English, Spanish, French, German, Portuguese, Italian.
 
-## 🛠️ Architecture
+## Architecture
 
 Built with a focus on performance and code quality. The key differentiator is the **Zero-Server Data Flow**:
 
@@ -71,7 +71,7 @@ graph TD
 - **Styling**: Tailwind CSS with a custom design system.
 - **Testing**: Playwright End-to-End test suite ensuring reliability across all operations.
 
-## ⚙️ Local Development
+## Local Development
 
 ### Prerequisites
 - Node.js 18+
@@ -98,17 +98,17 @@ graph TD
 4.  **Open in browser:**
     Navigate to [http://localhost:3000](http://localhost:3000).
 
-## 🤝 Contributing
+## Contributing
 
 Contributions are welcome! Whether it's fixing bugs, improving documentation, or proposing new features.
 
 Please read our [Contributing Guidelines](CONTRIBUTING.md) and [Code of Conduct](CODE_OF_CONDUCT.md) before getting started.
 
-## 📄 License
+## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
-## 💡 About the Name
+## About the Name
 
 "Lince" means **Lynx** in Spanish. The **Iberian Lynx** (*Lynx pardinus*) is a wild cat species native to the Iberian Peninsula (Spain/Portugal). It was once the most endangered feline species in the world, but conservation efforts are helping its population recover.
 

--- a/content/i18n-route-map.json
+++ b/content/i18n-route-map.json
@@ -4,21 +4,24 @@
     "en": "/en",
     "pt": "/pt",
     "de": "/de",
-    "it": "/it"
+    "it": "/it",
+    "fr": "/fr"
   },
   "faq": {
     "es": "/preguntas-frecuentes",
     "en": "/en/faq",
     "pt": "/pt/perguntas-frequentes",
     "de": "/de/haeufige-fragen",
-    "it": "/it/faq"
+    "it": "/it/faq",
+    "fr": "/fr/faq"
   },
   "support": {
     "es": "/apoya",
     "en": "/en/support",
     "pt": "/pt/apoie",
     "de": "/de/unterstuetzen",
-    "it": "/it/supporto"
+    "it": "/it/supporto",
+    "fr": "/fr/soutenir"
   },
   "operations": {
     "compress": {
@@ -26,63 +29,72 @@
       "en": "/en/compress",
       "pt": "/pt/comprimir",
       "de": "/de/komprimieren",
-      "it": "/it/comprimi"
+      "it": "/it/comprimi",
+      "fr": "/fr/compresser"
     },
     "merge": {
       "es": "/unir",
       "en": "/en/merge",
       "pt": "/pt/juntar",
       "de": "/de/zusammenfuehren",
-      "it": "/it/unisci"
+      "it": "/it/unisci",
+      "fr": "/fr/fusionner"
     },
     "split": {
       "es": "/dividir",
       "en": "/en/split",
       "pt": "/pt/dividir",
       "de": "/de/teilen",
-      "it": "/it/dividi"
+      "it": "/it/dividi",
+      "fr": "/fr/diviser"
     },
     "extract": {
       "es": "/extraer",
       "en": "/en/extract",
       "pt": "/pt/extrair",
       "de": "/de/seiten-extrahieren",
-      "it": "/it/estrai"
+      "it": "/it/estrai",
+      "fr": "/fr/extraire"
     },
     "crop": {
       "es": "/recortar",
       "en": "/en/crop",
       "pt": "/pt/recortar",
       "de": "/de/zuschneiden",
-      "it": "/it/ritaglia"
+      "it": "/it/ritaglia",
+      "fr": "/fr/recadrer"
     },
     "rotate": {
       "es": "/girar",
       "en": "/en/rotate",
       "pt": "/pt/girar",
       "de": "/de/drehen",
-      "it": "/it/ruota"
+      "it": "/it/ruota",
+      "fr": "/fr/faire-pivoter"
     },
     "reorder": {
       "es": "/reordenar",
       "en": "/en/reorder",
       "pt": "/pt/reordenar",
       "de": "/de/seiten-sortieren",
-      "it": "/it/riordina"
+      "it": "/it/riordina",
+      "fr": "/fr/reorganiser"
     },
     "pdfToImages": {
       "es": "/convertir-pdf-a-imagenes",
       "en": "/en/pdf-to-images",
       "pt": "/pt/pdf-para-imagens",
       "de": "/de/pdf-zu-bildern",
-      "it": "/it/da-pdf-a-immagini"
+      "it": "/it/da-pdf-a-immagini",
+      "fr": "/fr/pdf-en-images"
     },
     "imagesToPdf": {
       "es": "/crear-pdf-desde-imagenes",
       "en": "/en/images-to-pdf",
       "pt": "/pt/imagens-para-pdf",
       "de": "/de/bilder-zu-pdf",
-      "it": "/it/da-immagini-a-pdf"
+      "it": "/it/da-immagini-a-pdf",
+      "fr": "/fr/creer-pdf-depuis-images"
     }
   }
 }

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -18,10 +18,11 @@ PDFLince se creó para la comunidad hispanohablante, siendo ahora multilingüe, 
 
 ## Idiomas Disponibles / Available Languages
 
-PDFLince está disponible en 5 idiomas. Puedes acceder a la versión que prefieras:
+PDFLince está disponible en 6 idiomas. Puedes acceder a la versión que prefieras:
 
 - [Español (Principal)](https://pdflince.com)
 - [English](https://pdflince.com/en)
+- [Français](https://pdflince.com/fr)
 - [Deutsch](https://pdflince.com/de)
 - [Português](https://pdflince.com/pt)
 - [Italiano](https://pdflince.com/it)

--- a/src/app/(es)/layout.tsx
+++ b/src/app/(es)/layout.tsx
@@ -34,6 +34,8 @@ export const metadata = {
       'es': 'https://pdflince.com',
       'en': 'https://pdflince.com/en',
       'en-US': 'https://pdflince.com/en',
+      'fr': 'https://pdflince.com/fr',
+      'fr-FR': 'https://pdflince.com/fr',
       'pt': 'https://pdflince.com/pt',
       'pt-BR': 'https://pdflince.com/pt',
       'de': 'https://pdflince.com/de',

--- a/src/app/de/layout.tsx
+++ b/src/app/de/layout.tsx
@@ -31,6 +31,8 @@ export const metadata = {
       'es': 'https://pdflince.com',
       'en': 'https://pdflince.com/en',
       'en-US': 'https://pdflince.com/en',
+      'fr': 'https://pdflince.com/fr',
+      'fr-FR': 'https://pdflince.com/fr',
       'pt': 'https://pdflince.com/pt',
       'pt-BR': 'https://pdflince.com/pt',
       'de': 'https://pdflince.com/de',

--- a/src/app/en/layout.tsx
+++ b/src/app/en/layout.tsx
@@ -31,6 +31,8 @@ export const metadata = {
       'es': 'https://pdflince.com',
       'en': 'https://pdflince.com/en',
       'en-US': 'https://pdflince.com/en',
+      'fr': 'https://pdflince.com/fr',
+      'fr-FR': 'https://pdflince.com/fr',
       'pt': 'https://pdflince.com/pt',
       'pt-BR': 'https://pdflince.com/pt',
       'de': 'https://pdflince.com/de',

--- a/src/app/fr/(operations)/[operation]/page.tsx
+++ b/src/app/fr/(operations)/[operation]/page.tsx
@@ -1,0 +1,8 @@
+import { createLocaleOperationHandlers } from "../../../(helpers)/operation-handlers";
+
+const LOCALE = "fr" as const;
+
+const { generateStaticParams, generateMetadata, OperationPage } = createLocaleOperationHandlers(LOCALE);
+
+export { generateStaticParams, generateMetadata };
+export default OperationPage;

--- a/src/app/fr/faq/page.tsx
+++ b/src/app/fr/faq/page.tsx
@@ -1,0 +1,12 @@
+import { FaqPageContent } from "../../../components/FaqPageContent";
+import { getDictionary } from "../../../i18n/get-dictionary";
+import { createFaqMetadata } from "../../(helpers)/locale-metadata";
+
+const LOCALE = "fr" as const;
+
+export const generateMetadata = createFaqMetadata(LOCALE);
+
+export default function FrFaqPage() {
+  const dictionary = getDictionary(LOCALE);
+  return <FaqPageContent dictionary={dictionary} />;
+}

--- a/src/app/fr/layout.tsx
+++ b/src/app/fr/layout.tsx
@@ -14,15 +14,15 @@ import { SchemaOrg } from "../../components/SchemaOrg";
 
 import { METADATA_BASE, SHARED_ICONS, SHARED_OPEN_GRAPH } from "../../lib/metadata-shared";
 
-const LOCALE = "pt" as const;
+const LOCALE = "fr" as const;
 
 export const metadata = {
   metadataBase: METADATA_BASE,
-  title: "PDFLince - Juntar, Comprimir, Dividir e Converter PDFs Online",
-  description: "Ferramentas de PDF online gratuitas para juntar, comprimir, dividir, extrair e converter PDFs. 100% privado, processamento local no seu navegador.",
+  title: "PDFLince - Fusionner, Compresser, Diviser et Convertir des PDF",
+  description: "Outils PDF gratuits en ligne pour fusionner, compresser, diviser, extraire et convertir. 100% privé, traitement local dans votre navigateur.",
   icons: SHARED_ICONS,
   alternates: {
-    canonical: "https://pdflince.com/pt",
+    canonical: "https://pdflince.com/fr",
     languages: {
       'es-ES': 'https://pdflince.com',
       'es-MX': 'https://pdflince.com',
@@ -37,20 +37,22 @@ export const metadata = {
       'pt-BR': 'https://pdflince.com/pt',
       'de': 'https://pdflince.com/de',
       'de-DE': 'https://pdflince.com/de',
+      'it': 'https://pdflince.com/it',
+      'it-IT': 'https://pdflince.com/it',
       'x-default': 'https://pdflince.com',
     },
   },
   openGraph: {
     ...SHARED_OPEN_GRAPH,
-    title: "PDFLince - Ferramentas de PDF gratuitas e privadas no seu navegador",
-    description: "Combine, comprima, divida e converta PDFs sem carregar arquivos. Processamento seguro e 100% privado.",
-    url: "https://pdflince.com/pt",
-    locale: "pt_BR",
+    title: "PDFLince - Outils PDF gratuits et privés dans votre navigateur",
+    description: "Fusionnez, compressez, divisez et convertissez des PDF sans télécharger de fichiers. Sécurisé et 100% privé.",
+    url: "https://pdflince.com/fr",
+    locale: "fr_FR",
     type: "website",
   },
 };
 
-export default function PtLayout({ children }: { children: ReactNode }) {
+export default function FrLayout({ children }: { children: ReactNode }) {
   return (
     <html lang={LOCALE}>
       <head>

--- a/src/app/fr/page.tsx
+++ b/src/app/fr/page.tsx
@@ -1,0 +1,12 @@
+import { HomePageContent } from "../../components/HomePageContent";
+import { getDictionary } from "../../i18n/get-dictionary";
+import { createHomeMetadata } from "../(helpers)/locale-metadata";
+
+const LOCALE = "fr" as const;
+
+export const generateMetadata = createHomeMetadata(LOCALE);
+
+export default function FrHomePage() {
+  const dictionary = getDictionary(LOCALE);
+  return <HomePageContent dictionary={dictionary} />;
+}

--- a/src/app/fr/support/page.tsx
+++ b/src/app/fr/support/page.tsx
@@ -1,0 +1,10 @@
+import { SupportPageContent } from "../../../components/SupportPageContent";
+import { createSupportMetadata } from "../../(helpers)/locale-metadata";
+
+const LOCALE = "fr" as const;
+
+export const generateMetadata = createSupportMetadata(LOCALE);
+
+export default function FrSupportPage() {
+  return <SupportPageContent />;
+}

--- a/src/app/it/layout.tsx
+++ b/src/app/it/layout.tsx
@@ -31,6 +31,8 @@ export const metadata = {
       'es': 'https://pdflince.com',
       'en': 'https://pdflince.com/en',
       'en-US': 'https://pdflince.com/en',
+      'fr': 'https://pdflince.com/fr',
+      'fr-FR': 'https://pdflince.com/fr',
       'pt': 'https://pdflince.com/pt',
       'pt-BR': 'https://pdflince.com/pt',
       'de': 'https://pdflince.com/de',

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -6,9 +6,7 @@ export const revalidate = false;
 export default function robots(): MetadataRoute.Robots {
     const baseUrl = "https://pdflince.com";
 
-    // Cast to bypass Next.js restricted Sitemap type since it doesn't officially support 'host' yet
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const robotsObj: any = {
+    return {
         rules: {
             userAgent: "*",
             allow: "/",
@@ -17,8 +15,5 @@ export default function robots(): MetadataRoute.Robots {
             ],
         },
         sitemap: `${baseUrl}/sitemap.xml`,
-        host: "pdflince.com",
     };
-
-    return robotsObj as MetadataRoute.Robots;
 }

--- a/src/components/pdf-processor/ProcessingStatusDialog.tsx
+++ b/src/components/pdf-processor/ProcessingStatusDialog.tsx
@@ -35,6 +35,7 @@ interface ProcessingStatusDialogProps {
   description?: string;
   highlights?: DialogHighlight[];
   donationPrompt?: DonationPrompt | null;
+  sharePrompt?: { dialogMessage: string; shareText: string; actionLabel: string; copiedLabel: string } | null;
   actions?: DialogAction[];
   closeLabel: string;
   onClose: () => void;
@@ -110,14 +111,43 @@ export function ProcessingStatusDialog({
   description,
   highlights,
   donationPrompt,
+  sharePrompt,
   actions,
   closeLabel,
   onClose,
   analyticsContext,
 }: ProcessingStatusDialogProps) {
   const [mounted, setMounted] = useState(false);
+  const [copied, setCopied] = useState(false);
   const previousFocus = useRef<Element | null>(null);
   const closeButtonRef = useRef<HTMLButtonElement | null>(null);
+
+  const handleShareClick = async () => {
+    const currentLocale = window.location.pathname.split('/')[1] || 'en';
+    const shareUrl = `https://pdflince.com/${currentLocale}?utm_source=app&utm_medium=share&utm_campaign=user_referral_success`;
+
+    const shareData = {
+      title: 'PDFLince - Free Private PDF Toolkit',
+      text: sharePrompt ? `${sharePrompt.shareText}\n` : undefined,
+      url: shareUrl
+    };
+
+    if (navigator.share && navigator.canShare && navigator.canShare(shareData)) {
+      try {
+        await navigator.share(shareData);
+      } catch {
+        // User aborted
+      }
+    } else {
+      try {
+        await navigator.clipboard.writeText(shareUrl);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      } catch {
+        // Fallback failed
+      }
+    }
+  };
 
   useEffect(() => {
     setMounted(true);
@@ -279,7 +309,22 @@ export function ProcessingStatusDialog({
           ) : null}
 
           {status === 'success' && (
-            <div className="border-t border-[var(--ui-2)] pt-4">
+            <div className="border-t border-[var(--ui-2)] pt-4 space-y-4">
+              {sharePrompt && (
+                <div className="rounded-md border border-[var(--ui-3)] bg-[var(--bg-2)] p-4 flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+                  <p className="text-sm text-[var(--tx-2)] flex-1">{sharePrompt.dialogMessage}</p>
+                  <button
+                    type="button"
+                    onClick={handleShareClick}
+                    className="inline-flex shrink-0 items-center justify-center rounded-md border border-[var(--ui-3)] bg-white px-3 py-1.5 text-sm font-medium text-[var(--tx)] shadow-sm transition hover:bg-[var(--bg-2)] focus:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+                  >
+                    <svg className="mr-2 h-4 w-4 text-[var(--tx-3)]" fill="none" viewBox="0 0 24 24" strokeWidth="1.5" stroke="currentColor">
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M7.217 10.907a2.25 2.25 0 100 2.186m0-2.186c.18.324.283.696.283 1.093s-.103.77-.283 1.093m0-2.186l9.566-5.314m-9.566 7.5l9.566 5.314m0 0a2.25 2.25 0 103.935 2.186 2.25 2.25 0 00-3.935-2.186zm0-12.814a2.25 2.25 0 103.933-2.185 2.25 2.25 0 00-3.933 2.185z" />
+                    </svg>
+                    {copied ? sharePrompt.copiedLabel : sharePrompt.actionLabel}
+                  </button>
+                </div>
+              )}
               <FeedbackWidget operation={analyticsContext?.mode} />
             </div>
           )}

--- a/src/components/pdf-processor/index.tsx
+++ b/src/components/pdf-processor/index.tsx
@@ -1,4 +1,4 @@
-﻿"use client";
+"use client";
 
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import FileUploader from './FileUploader';
@@ -2474,6 +2474,7 @@ export default function PDFProcessor({ initialMode = 'merge' }: { initialMode?: 
           description={statusDialogState.description}
           highlights={statusDialogState.highlights}
           donationPrompt={statusDialogState.donationPrompt}
+          sharePrompt={statusDialogStrings.sharePrompt}
           actions={dialogActions}
           closeLabel={statusDialogStrings.closeLabel}
           onClose={handleDialogClose}

--- a/src/components/seo/BreadcrumbSchema.tsx
+++ b/src/components/seo/BreadcrumbSchema.tsx
@@ -4,42 +4,12 @@ import { usePathname } from "next/navigation";
 import Script from "next/script";
 import { useMemo } from "react";
 import { useDictionary } from "../../i18n/LocaleProvider";
-import { OperationKey } from "../../types/operations";
+import { SUPPORTED_LOCALES } from "../../i18n/config";
+import { buildGlobalSlugToOperationMap, buildFaqSegmentSet } from "../../i18n/routing";
 
-// Map of route segments to OperationKeys or other keys
-const SEGMENT_LABEL_MAP: Record<string, OperationKey> = {
-    // Spanish
-    "comprimir-pdf": "compress",
-    "unir-pdf": "merge",
-    "dividir-pdf": "split",
-    "extraer-paginas": "extract",
-    "ordenar-pdf": "reorder",
-    "pdf-a-jpg": "pdfToImages",
-    "jpg-a-pdf": "imagesToPdf",
-    // English
-    "compress-pdf": "compress",
-    "merge-pdf": "merge",
-    "split-pdf": "split",
-    "extract-pages": "extract",
-    "organize-pdf": "reorder",
-    "pdf-to-jpg": "pdfToImages",
-    "jpg-to-pdf": "imagesToPdf",
-    // German
-    "pdf-komprimieren": "compress",
-    "pdf-zusammenfugen": "merge",
-    "pdf-teilen": "split",
-    "seiten-extrahieren": "extract",
-    "pdf-ordnen": "reorder",
-    "pdf-in-jpg": "pdfToImages",
-    "pdf-in-jpeg": "pdfToImages", // Alternate
-    "jpg-in-pdf": "imagesToPdf",
-    // Portuguese
-    "juntar-pdf": "merge",
-    "extrair-paginas": "extract",
-    "pdf-para-jpg": "pdfToImages",
-    "jpg-para-pdf": "imagesToPdf",
-    // Duplicates handled by JS object behavior (last one wins), but we should explicitely list unique ones in source code to avoid linter errors
-};
+// Dynamically built from i18n-route-map.json — never goes stale when slugs change or languages are added.
+const SLUG_TO_OPERATION = buildGlobalSlugToOperationMap();
+const FAQ_SEGMENTS = buildFaqSegmentSet();
 
 export function BreadcrumbSchema() {
     const pathname = usePathname();
@@ -54,7 +24,7 @@ export function BreadcrumbSchema() {
         const segments = pathname.split('/').filter(Boolean);
 
         // Skip if just home "/" or "/es"
-        const isHome = segments.length === 0 || (segments.length === 1 && ["es", "en", "de", "pt"].includes(segments[0]));
+        const isHome = segments.length === 0 || (segments.length === 1 && (SUPPORTED_LOCALES as readonly string[]).includes(segments[0]));
 
         if (isHome) {
             return null;
@@ -76,14 +46,14 @@ export function BreadcrumbSchema() {
         let label = lastSegment;
 
         // Attempt to lookup friendly name
-        const lookupKey = SEGMENT_LABEL_MAP[lastSegment];
+        const operationKey = SLUG_TO_OPERATION[lastSegment];
         const operations = dictionary.operations;
 
-        if (lookupKey && operations && operations[lookupKey]) {
-            // It's an operation
-            label = operations[lookupKey].meta.title;
-        } else if (lastSegment === 'faq' || lastSegment === 'preguntas-frecuentes') {
-            label = dictionary.pages.faq.title; // Or components.nav.faq
+        if (operationKey && operations && operations[operationKey]) {
+            // It's an operation - use the short footer navigation label, NOT the full SEO meta title
+            label = dictionary.components.footer.operations[operationKey];
+        } else if (FAQ_SEGMENTS.has(lastSegment)) {
+            label = dictionary.pages.faq.title;
         } else {
             // Fallback formatting
             label = lastSegment.replace(/-/g, ' ').replace(/\b\w/g, l => l.toUpperCase());

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -1,4 +1,4 @@
-export const SUPPORTED_LOCALES = ["es", "en", "pt", "de", "it"] as const;
+export const SUPPORTED_LOCALES = ["es", "en", "pt", "de", "it", "fr"] as const;
 
 export type Locale = typeof SUPPORTED_LOCALES[number];
 
@@ -11,6 +11,7 @@ export const localeLabels: Record<Locale, { label: string; nativeName: string; h
     pt: { label: "Português", nativeName: "Português", htmlLang: "pt", hrefLang: "pt" },
     de: { label: "Deutsch", nativeName: "Deutsch", htmlLang: "de", hrefLang: "de" },
     it: { label: "Italiano", nativeName: "Italiano", htmlLang: "it", hrefLang: "it" },
+    fr: { label: "Français", nativeName: "Français", htmlLang: "fr", hrefLang: "fr" },
   };
 
 export function isLocale(value: string): value is Locale {

--- a/src/i18n/dictionaries/de/index.ts
+++ b/src/i18n/dictionaries/de/index.ts
@@ -340,6 +340,12 @@ export const deDictionary: Dictionary = {
         errorDescription: "Die Operation konnte nicht abgeschlossen werden. Prüfe die Dateien und versuche es erneut.",
         retryLabel: "Erneut versuchen",
         closeLabel: "Schließen",
+        sharePrompt: {
+          dialogMessage: "PDFLince ist völlig kostenlos und respektiert Ihre Privatsphäre. Helfen Sie uns, dass es so bleibt, indem Sie es mit einem Kollegen teilen.",
+          shareText: "Ich habe gerade PDFLince genutzt, um meine PDFs zu bearbeiten. Es ist ein kostenloses, schnelles und 100% privates Toolkit, um PDFs direkt im Browser zu teilen, zu komprimieren, zusammenzuführen und zu konvertieren. Perfekt für sensible Dokumente!",
+          actionLabel: "Teilen",
+          copiedLabel: "Kopiert!",
+        },
       },
       compressionTotal: {
         title: "Gesamteinsparung (alle Dateien)",

--- a/src/i18n/dictionaries/dictionary-types.ts
+++ b/src/i18n/dictionaries/dictionary-types.ts
@@ -177,6 +177,12 @@ export interface PdfProcessorStrings {
     errorDescription: string;
     retryLabel: string;
     closeLabel: string;
+    sharePrompt: {
+      dialogMessage: string;
+      shareText: string;
+      actionLabel: string;
+      copiedLabel: string;
+    };
   };
   compressionTotal: {
     title: string;

--- a/src/i18n/dictionaries/en/index.ts
+++ b/src/i18n/dictionaries/en/index.ts
@@ -339,6 +339,12 @@ export const enDictionary: Dictionary = {
         errorDescription: "We couldn't finish this operation. Check the files and try again.",
         retryLabel: "Retry",
         closeLabel: "Close",
+        sharePrompt: {
+          dialogMessage: "PDFLince is completely free and respects your privacy. Help us keep it that way by sharing it with a colleague.",
+          shareText: "I just used PDFLince to manage my PDFs. It's a free, fast, and completely private toolkit to split, compress, merge, and convert PDFs directly in the browser. Perfect for sensitive documents!",
+          actionLabel: "Share",
+          copiedLabel: "Copied!",
+        },
       },
       compressionTotal: {
         title: "Total Savings (all files)",

--- a/src/i18n/dictionaries/es/index.ts
+++ b/src/i18n/dictionaries/es/index.ts
@@ -333,6 +333,12 @@ export const esDictionary: Dictionary = {
         errorDescription: "No pudimos completar la operación. Revisa los archivos e inténtalo otra vez.",
         retryLabel: "Intentar nuevamente",
         closeLabel: "Cerrar",
+        sharePrompt: {
+          dialogMessage: "PDFLince es completamente gratis y respeta tu privacidad. Ayúdanos a mantenerlo así compartiéndolo con un colega.",
+          shareText: "Acabo de usar PDFLince para gestionar mis PDFs. Es una herramienta gratuita, rápida y totalmente privada para dividir, comprimir, unir y convertir PDFs directamente en el navegador. ¡Perfecta para documentos sensibles!",
+          actionLabel: "Compartir",
+          copiedLabel: "¡Copiado!",
+        },
       },
       compressionTotal: {
         title: "Ahorro total (todos los archivos)",

--- a/src/i18n/dictionaries/fr/faqs.ts
+++ b/src/i18n/dictionaries/fr/faqs.ts
@@ -1,0 +1,63 @@
+export const faqsFr = {
+  common: [
+    {
+      question: "Comment fonctionne PDFLince sans télécharger mes documents sur des serveurs ?",
+      answer:
+        "PDFLince fonctionne entièrement dans votre navigateur avec un moteur de traitement sur l'appareil. Aucun fichier n'est téléchargé sur nos serveurs, ce qui garantit une confidentialité totale et un traitement rapide.",
+    },
+    {
+      question: "PDFLince est-il sûr pour les documents confidentiels ?",
+      answer:
+        "Absolument. Tout reste sur votre appareil, de sorte que vos PDF ne quittent jamais votre contrôle — nous ne pouvons même pas accéder à leur contenu.",
+    },
+    {
+      question: "Y a-t-il une limite à la taille ou au nombre de PDF que je peux traiter ?",
+      answer:
+        "La principale limite est la mémoire de votre appareil. Dans la plupart des cas, PDFLince traite des fichiers allant jusqu'à 50 Mo chacun, bien que cela puisse varier en fonction de votre matériel et de votre navigateur.",
+    },
+    {
+      question: "PDFLince fonctionne-t-il sur les appareils mobiles ?",
+      answer:
+        "Oui. PDFLince est optimisé pour les ordinateurs de bureau, les tablettes et les téléphones. L'interface s'adapte à toutes les tailles d'écran.",
+    },
+  ],
+  regional: [
+    {
+      question: "PDFLince m'aide-t-il à respecter les règles de protection des données ?",
+      answer:
+        "Parce que le traitement se fait localement, aucune donnée personnelle ne quitte votre organisation. Cela facilite le respect du RGPD, du HIPAA, du LGPD ou de toute politique de confidentialité interne.",
+    },
+    {
+      question: "Puis-je utiliser PDFLince pour des formulaires officiels ou des factures ?",
+      answer:
+        "Oui. Il est idéal pour optimiser les factures, les contrats et les documents de l'administration publique tout en conservant la qualité d'origine.",
+    },
+    {
+      question: "La compression affectera-t-elle la validité légale de mes documents ?",
+      answer:
+        "Le compresseur PDFLince préserve l'intégrité du document. Même ainsi, nous vous recommandons de confirmer que le fichier résultant répond aux exigences spécifiques de l'entité réceptrice lorsque les enjeux sont élevés.",
+    },
+  ],
+  tech: [
+    {
+      question: "Quelle technologie propulse PDFLince ?",
+      answer:
+        "PDFLince utilise un moteur JavaScript léger pour manipuler nativement les PDF dans le navigateur sans dépendre d'extensions natives. Cela permet de garder l'application plus légère et la maintenance plus simple.",
+    },
+    {
+      question: "Les éléments interactifs sont-ils perdus lorsque je compresse un PDF ?",
+      answer:
+        "Dans la plupart des cas, PDFLince conserve les liens, les formulaires et les signets. Avec une compression très agressive, certaines fonctionnalités avancées peuvent être modifiées, nous vous recommandons donc de vérifier.",
+    },
+    {
+      question: "Quels navigateurs sont compatibles avec PDFLince ?",
+      answer:
+        "PDFLince fonctionne avec les navigateurs modernes tels que Chrome, Firefox, Safari, Edge et Opera. Tout ce dont vous avez besoin est un navigateur à jour prenant en charge ES2020 — aucun runtime supplémentaire n'est requis.",
+    },
+    {
+      question: "Puis-je convertir un PDF vers d'autres formats ?",
+      answer:
+        "Actuellement, vous pouvez convertir des PDF en images (PNG ou JPEG) et créer des PDF à partir de JPG, PNG ou WEBP sans télécharger de fichiers. Pour d'autres formats de niche, continuez à utiliser un convertisseur dédié pendant que nous continuons à développer la boîte à outils.",
+    },
+  ],
+};

--- a/src/i18n/dictionaries/fr/index.ts
+++ b/src/i18n/dictionaries/fr/index.ts
@@ -339,6 +339,12 @@ export const frDictionary: Dictionary = {
         errorDescription: "Nous n'avons pas pu terminer cette opération. Vérifiez les fichiers.",
         retryLabel: "Réessayer",
         closeLabel: "Fermer",
+        sharePrompt: {
+          dialogMessage: "PDFLince est entièrement gratuit et respecte votre vie privée. Aidez-nous à le garder ainsi en le partageant avec un collègue.",
+          shareText: "Je viens d'utiliser PDFLince pour gérer mes PDF. C'est une boîte à outils gratuite, rapide et totalement privée pour diviser, compresser, fusionner et convertir des PDF directement dans le navigateur. Idéal pour les documents sensibles !",
+          actionLabel: "Partager",
+          copiedLabel: "Copié !",
+        },
       },
       compressionTotal: {
         title: "Économies totales",

--- a/src/i18n/dictionaries/fr/index.ts
+++ b/src/i18n/dictionaries/fr/index.ts
@@ -1,0 +1,715 @@
+import { localeLabels } from "../../config";
+import { getRoutePath, getOperationPath } from "../../routing";
+import { operationsFr } from "./operations";
+import { faqsFr } from "./faqs";
+import type { Dictionary } from "../dictionary-types";
+import { OperationKey } from "../../../types/operations";
+
+const locale = "fr" as const;
+const { label, nativeName, htmlLang, hrefLang } = localeLabels[locale];
+const siteUrl = "https://pdflince.com";
+const homePath = getRoutePath(locale, "home");
+
+const operationsRoutes: Record<OperationKey, string> = {
+  merge: getOperationPath(locale, "merge"),
+  compress: getOperationPath(locale, "compress"),
+  split: getOperationPath(locale, "split"),
+  extract: getOperationPath(locale, "extract"),
+  crop: getOperationPath(locale, "crop"),
+  rotate: getOperationPath(locale, "rotate"),
+  reorder: getOperationPath(locale, "reorder"),
+  pdfToImages: getOperationPath(locale, "pdfToImages"),
+  imagesToPdf: getOperationPath(locale, "imagesToPdf"),
+};
+
+export const frDictionary: Dictionary = {
+  locale,
+  localeLabel: label,
+  nativeName,
+  htmlLang,
+  hrefLang,
+  routes: {
+    home: homePath,
+    faq: getRoutePath(locale, "faq"),
+    support: getRoutePath(locale, "support"),
+    operations: operationsRoutes,
+  },
+  metadata: {
+    site: {
+      title: "PDFLince – Fusionner, compresser et convertir des PDF gratuitement",
+      description:
+        "PDFLince est une boîte à outils axée sur la confidentialité qui fusionne, compresse, divise, extrait, pivote et convertit des PDF directement dans votre navigateur. Tout le traitement reste sur l'appareil.",
+      keywords: [
+        "fusionner pdf",
+        "compresser pdf",
+        "diviser pdf",
+        "extraire pages pdf",
+        "pivoter pages pdf",
+        "réorganiser pdf",
+        "pdf en images",
+        "images en pdf",
+        "convertir pdf",
+        "convertir pdf en ligne",
+        "convertir pdf en png",
+        "jpg en pdf",
+        "modifier pdf hors ligne",
+        "boîte à outils pdf",
+        "confidentialité pdf",
+      ],
+      canonical: `${siteUrl}${homePath}`,
+      openGraph: {
+        title: "PDFLince – Fusionner, Compresser, Diviser, PDF en Image",
+        description:
+          "Fusionnez, compressez, divisez, extrayez, réorganisez et convertissez des PDF sans télécharger de fichiers. Gratuit, privé et soutenu par un traitement entièrement local.",
+        url: `${siteUrl}${homePath}`,
+        locale: "fr_FR",
+        type: "website",
+        imageUrl: "https://pdflince.com/og-image.jpg",
+        imageAlt: "PDFLince - Traitement PDF privé et gratuit",
+      },
+    },
+    faq: {
+      title: "FAQ | PDFLince – Boîte à outils de traitement PDF gratuite",
+      description:
+        "Réponses aux questions fréquentes sur PDFLince. Apprenez comment fusionner, compresser, diviser, extraire et réorganiser des PDF sans télécharger vos fichiers.",
+      keywords: [
+        "pdflince faq",
+        "questions pdf",
+        "aide pdf",
+        "aide fusion pdf",
+        "aide compression pdf",
+        "aide division pdf",
+        "rotation pages pdf",
+        "réorganiser pdf",
+      ],
+      canonical: `${siteUrl}${getRoutePath(locale, "faq")}`,
+    },
+    support: {
+      title: "Soutenir PDFLince | Gardez la boîte à outils gratuite et privée",
+      description:
+        "Votre don permet à PDFLince de rester petit, indépendant et axé sur la confidentialité. Aidez à couvrir l'hébergement et les améliorations.",
+      keywords: [
+        "faire un don pdflince",
+        "soutenir boîte outils pdf",
+        "financer projets confidentialité",
+        "dons stripe pdflince",
+        "garder pdflince gratuit",
+      ],
+      canonical: `${siteUrl}${getRoutePath(locale, "support")}`,
+    },
+    operations: operationsFr,
+  },
+  brand: {
+    name: "PDFLince",
+    tagline: "Traitement local • 100% privé",
+  },
+  components: {
+    nav: {
+      home: "Accueil",
+      faq: "FAQ",
+      support: "Soutenir",
+      photo: "FotoLince",
+      languageLabel: "Langue",
+      menuLabel: "Basculer le menu de navigation",
+    },
+    footer: {
+      privacy: "Traitement local • 100% privé • Licences ouvertes",
+      rights: `© ${new Date().getFullYear()} PDFLince — Outils pour manipuler des PDF sans compromettre la confidentialité`,
+      links: {
+        home: "Accueil",
+        faq: "FAQ",
+        support: "Soutenir",
+        photo: "FotoLince",
+        contact: "Contact",
+      },
+      capabilitiesLabel: "Actions populaires",
+      operations: {
+        merge: "Fusionner des PDF",
+        compress: "Compresser un PDF",
+        split: "Diviser un PDF",
+        extract: "Extraire des pages",
+        crop: "Recadrer des pages",
+        rotate: "Faire pivoter",
+        reorder: "Réorganiser",
+        pdfToImages: "PDF en images",
+        imagesToPdf: "Images en PDF",
+      },
+      license: "Traitement PDF: PDF-lib (MIT), PDF.js (Apache 2.0) • Police: Geist (MIT)",
+      disclaimer: "Le service est fourni « tel quel » sans garantie d'aucune sorte. L'utilisateur est responsable de l'utilisation des fichiers.",
+    },
+    notifications: {
+      labels: {
+        success: "Succès",
+        error: "Erreur",
+        info: "Avis",
+        warning: "Avertissement",
+      },
+      closeLabel: "Fermer",
+    },
+    fotolinceBanner: {
+      eyebrow: "Besoin d'optimiser des images ?",
+      title: "Compressez, redimensionnez ou convertissez avec FotoLince",
+      description:
+        "Notre boîte à outils gère les JPG, PNG et WEBP localement — parfait pour réduire les visuels avant de créer un PDF.",
+      ctaLabel: "Ouvrir FotoLince",
+      ctaHref: "https://fotolince.com",
+      imageAlt: "Logo FotoLince",
+    },
+    feedback: {
+      question: "Cela a-t-il été utile ?",
+      thanks: "Merci pour vos commentaires !",
+      whatWrong: "Dites-nous ce qui s'est mal passé",
+      emailSubject: "Commentaires pour PDFLince",
+    },
+    pdfProcessor: {
+      title: "Choisissez une opération",
+      modes: {
+        merge: {
+          label: "Fusionner PDF",
+          helper: "Organisez les PDF pour les fusionner en un seul document.",
+        },
+        compress: {
+          label: "Compresser PDF",
+          helper: "Réduisez la taille d'un PDF. Traitez un fichier à la fois pour le meilleur équilibre entre qualité et vitesse.",
+        },
+        split: {
+          label: "Diviser PDF",
+          helper: "Choisissez des PDF pour les diviser en documents séparés.",
+        },
+        extract: {
+          label: "Extraire Pages",
+          helper: "Choisissez des pages spécifiques pour créer un nouveau document.",
+        },
+        crop: {
+          label: "Recadrer Pages",
+          helper: "Coupez les marges visibles des pages sélectionnées sans quitter le navigateur.",
+        },
+        rotate: {
+          label: "Faire Pivoter",
+          helper: "Sélectionnez les pages qui nécessitent une nouvelle orientation et faites-les pivoter.",
+        },
+        reorder: {
+          label: "Réorganiser",
+          helper: "Modifiez l'ordre des pages à l'intérieur d'un PDF.",
+        },
+        pdfToImages: {
+          label: "PDF en images",
+          helper: "Exportez chaque page PDF au format PNG ou JPEG sans téléchargement.",
+        },
+        imagesToPdf: {
+          label: "Images en PDF",
+          helper: "Combinez des images JPG, PNG ou WEBP dans un PDF avec une mise en page personnalisée.",
+        },
+      },
+      upload: {
+        title: "Sélectionnez vos fichiers",
+        clearAll: "Tout effacer",
+        listHeadings: {
+          merge: "Fichiers à fusionner (réorganiser pour définir la séquence) :",
+          extract: "Sélectionnez un fichier pour travailler avec ses pages :",
+          crop: "Sélectionnez un fichier pour travailler avec ses pages :",
+          rotate: "Sélectionnez un fichier pour travailler avec ses pages :",
+          reorder: "Sélectionnez un fichier pour travailler avec ses pages :",
+          pdfToImages: "PDF à convertir (traités un par un) :",
+          imagesToPdf: "Images à combiner (réorganiser pour la séquence finale) :",
+          default: "Fichiers sélectionnés (réorganiser ou supprimer) :",
+        },
+        hints: {
+          compress: "Chaque fichier est compressé individuellement en utilisant le meilleur équilibre qualité-taille.",
+          split: "Chaque PDF sera divisé en fonction des options que vous sélectionnez à l'étape suivante.",
+          crop: "Choisissez les pages à recadrer, puis définissez combien de points couper de chaque côté.",
+          pdfToImages: "Nous traitons un PDF à la fois. Ajustez le format et le DPI avant d'exporter.",
+          imagesToPdf: "Déposez des images JPG, PNG, WEBP ou TIFF. Utilisez le panneau d'options pour choisir la taille, les marges et la couleur.",
+        },
+      },
+      downloadNames: {
+        compress: "compresse_PDFLince",
+        merge: "fusionne_PDFLince",
+        split: "partie_PDFLince",
+        extract: "extrait_PDFLince",
+        crop: "recadre_PDFLince",
+        rotate: "pivote_PDFLince",
+        reorder: "reorganise_PDFLince",
+        pdfToImages: "images_PDFLince",
+        imagesToPdf: "images_vers_pdf_PDFLince",
+      },
+      processButton: {
+        idleSingle: "Traiter 1 fichier",
+        idleMultiple: (count: number) => `Traiter ${count} fichiers`,
+        processing: "Traitement en cours...",
+        extract: (count: number) => `Extraire ${count} page${count > 1 ? "s" : ""}`,
+        crop: (count: number) =>
+          count > 0 ? `Recadrer ${count} page${count > 1 ? "s" : ""}` : "Recadrer PDF",
+        rotate: (count: number) =>
+          count > 0 ? `Pivoter ${count} page${count > 1 ? "s" : ""}` : "Pivoter PDF",
+        reorder: "Enregistrer l'ordre",
+        pdfToImages: {
+          single: "Exporter images",
+          multiple: (count: number) => `Exporter ${count} PDF`,
+        },
+        imagesToPdf: {
+          single: "Créer PDF",
+          multiple: (count: number) => `Créer un PDF à partir de ${count} images`,
+        },
+      },
+      statusMessages: {
+        info: (mode: string) => `Traitement en cours (${mode})...`,
+        compressed: (reduction: string, original: string, next: string, seconds: string) =>
+          `Compressé. Réduction : ${reduction}% (${original} → ${next}) en ${seconds}s`,
+        merged: "Fusion terminée",
+        split: (count: number) =>
+          count > 1
+            ? `Généré ${count} fichiers. Téléchargement du premier...`
+            : "Division terminée",
+        extracted: (count: number) => `Extrait ${count} page${count > 1 ? "s" : ""}`,
+        cropped: (count: number) => `Recadré ${count} page${count > 1 ? "s" : ""}`,
+        rotated: (count: number) => `Pivoté ${count} page${count > 1 ? "s" : ""}`,
+        reordered: "Réorganisation terminée",
+        pdfToImages: (count: number, format: "png" | "jpeg", zipped: boolean) => {
+          const label = format === "png" ? "PNG" : "JPEG";
+          return zipped
+            ? `Exporté ${count} image${count > 1 ? "s" : ""} ${label} dans une archive ZIP`
+            : `Téléchargé ${count} image${count > 1 ? "s" : ""} ${label}`;
+        },
+        imagesToPdf: (count: number) =>
+          `PDF créé à partir de ${count} image${count > 1 ? "s" : ""}`,
+        imageFormatLabels: {
+          png: "PNG",
+          jpeg: "JPEG",
+        },
+      },
+      errors: {
+        noFiles: "Aucun résultat produit",
+        mergeRequiresTwo: "Sélectionnez au moins deux fichiers",
+        noPagesSelected: "Choisissez au moins une page",
+        invalidFile: "Choisissez un fichier valide",
+        reorderEmpty: "Aucun nouvel ordre détecté",
+        unknown: "Erreur inconnue",
+        modeNotSupported: "Mode non pris en charge",
+      },
+      labels: {
+        pagesToExtract: "Sélectionnez les pages à extraire :",
+        pagesToCrop: "Sélectionnez les pages à recadrer :",
+        pagesToRotate: "Sélectionnez les pages à pivoter :",
+        reorderPages: "Faites glisser les pages pour les réorganiser :",
+      },
+      compressionPreview: {
+        title: "Aperçu de la compression",
+        description:
+          "Ajustez les paramètres pour estimer la taille de sortie avant de lancer la compression.",
+        running: "Calcul de l'aperçu…",
+        readyLabel: "Sortie estimée",
+        ratio: (percent: string) => `${percent}% plus petit`,
+        saved: (size: string) => `${size} économisés`,
+        time: (seconds: string) => `≈ ${seconds}s`,
+        original: "Original",
+        result: "Estimé",
+        notice:
+          "L'aperçu s'exécute localement. Rien n'est téléchargé sur nos serveurs.",
+        error: "L'aperçu n'a pas pu être généré.",
+        retry: "Réessayer l'aperçu",
+        universalBadge: "Optimisation Universelle",
+      },
+      compressionSummary: {
+        title: "Dernière compression",
+        ratio: (percent: string) => `${percent}% plus petit`,
+        saved: (size: string) => `${size} économisés`,
+        original: "Original",
+        result: "Compressé",
+        duration: (seconds: string) => `Terminé en ${seconds}s`,
+        download: "Télécharger à nouveau",
+        clear: "Effacer le résumé",
+      },
+      donationReminder: {
+        message: "PDFLince vous a-t-il fait gagner du temps ? Votre soutien le garde gratuit.",
+        actionLabel: "Soutenir PDFLince",
+        withSavings: (percent: string, saved: string) =>
+          `Économisé ${saved} (${percent}%) ? Aidez à garder PDFLince sans publicité.`,
+      },
+      statusDialog: {
+        processingTitle: "Traitement local",
+        successTitle: "Vos fichiers sont prêts",
+        successDescription:
+          "Les téléchargements démarrent automatiquement.",
+        resultsLabel: "Dernier résultat",
+        filesProcessedLabel: (count: number) =>
+          `${count} fichier${count > 1 ? "s" : ""} traité${count > 1 ? "s" : ""}`,
+        downloadAgainLabel: "Télécharger",
+        errorTitle: "Échec du traitement",
+        errorDescription: "Nous n'avons pas pu terminer cette opération. Vérifiez les fichiers.",
+        retryLabel: "Réessayer",
+        closeLabel: "Fermer",
+      },
+      compressionTotal: {
+        title: "Économies totales",
+        savings: (size: string) => `${size} économisés au total`,
+        count: (count: number) => `${count} fichiers optimisés`,
+      },
+    },
+    fileUploader: {
+      clickToSelect: "Cliquez pour sélectionner",
+      orDrop: (type: "pdf" | "images") =>
+        type === "images" ? "ou glissez-déposez des images" : "ou glissez-déposez des fichiers PDF",
+      accepted: {
+        pdf: "Fichiers PDF",
+        images: "Formats acceptés: JPG, PNG, WEBP, TIFF",
+      },
+      maxSize: (sizeMb: number) => `Taille recommandée : < ${sizeMb}Mo`,
+      errors: {
+        invalidType: (fileName: string, label: string) =>
+          `Type non pris en charge: ${fileName}. Seuls ${label} sont autorisés.`,
+        tooLarge: (fileName: string, sizeMb: number) =>
+          `Fichier trop volumineux: ${fileName}. La taille maximale est de ${sizeMb}Mo.`,
+      },
+      dropImagesAlt: "Image d'espace réservé",
+    },
+    fileList: {
+      moveUp: "Monter",
+      moveDown: "Descendre",
+      remove: "Retirer",
+      removeAll: "Tout retirer",
+      imageLabel: "Image",
+      fileLabel: "Fichier",
+      selected: "Sélectionné",
+      pdfLabel: "PDF",
+      deselect: "Désélectionner",
+      pagesLabel: (count: number) => `${count} page${count > 1 ? "s" : ""}`,
+      previewLoading: "Chargement de l'aperçu…",
+    },
+    pageSelector: {
+      loading: "Chargement des pages...",
+      error: "Les informations du PDF n'ont pas pu être chargées",
+      summary: (total: number, selected: number) =>
+        `${total} pages détectées — ${selected} sélectionnées`,
+      selectAll: "Tout sélectionner",
+      deselectAll: "Tout désélectionner",
+      pageLabel: (pageNumber: number) => `Page ${pageNumber}`,
+      extraPages: (shown: number, total: number) =>
+        `Affichage de ${shown} sur ${total} pages. Saisissez les numéros des pages supplémentaires.`,
+      manualLabel: "Saisir numéros (ex. 21, 25-30)",
+      manualPlaceholder: "21, 25-30, 42",
+    },
+    pageOrderer: {
+      loading: "Chargement des pages...",
+      error: "Les informations du PDF n'ont pas pu être chargées",
+      limitReached: (count: number) =>
+        `Ce PDF compte ${count} pages. Pour des raisons de performances, vous pouvez réorganiser jusqu'à 120 pages.`,
+      limitHint:
+        "Divisez d'abord le PDF en morceaux plus petits.",
+      summary: (count: number) => `${count} pages prêtes à être réorganisées`,
+      reset: "Restaurer l'ordre",
+      dragHint: "Faites glisser pour modifier l'ordre",
+      pageLabel: (pageNumber: number) => `Page ${pageNumber}`,
+      originalLabel: (pageNumber: number) => `Original: Page ${pageNumber}`,
+      instructions:
+        'Faites glisser les pages. Une fois terminé, cliquez sur "Enregistrer l\'ordre".',
+    },
+    processingOptions: {
+      compress: {
+        title: "Compression",
+        level: "Niveau",
+        levels: {
+          low: "Faible",
+          medium: "Moyen",
+          high: "Élevé",
+        },
+        removeMetadata: "Supprimer métadonnées",
+        removeMetadataHint: "Supprime les détails cachés comme l'auteur et l'historique.",
+        stripAnnotations: "Supprimer les annotations",
+        stripAnnotationsHint: "Supprime les notes, les formulaires et les signatures.",
+        downscaleImages: "Réduire les images",
+        downscaleHint: "Idéal pour les documents numérisés.",
+        advancedTitle: "Nettoyage avancé",
+        advancedDescription: "Gardez-le simple ou activez les extras dont vous avez besoin.",
+        activeLabel: "Activé :",
+      },
+      merge: {
+        title: "Fusionner",
+        pageDivider: "Page vierge entre les documents",
+        metadataTitle: "Titre du document fusionné (facultatif)",
+        metadataAuthor: "Auteur du document (facultatif)",
+        metadataHint: "Définissez des métadonnées personnalisées.",
+      },
+      split: {
+        title: "Diviser",
+        pagesPerFile: "Pages par fichier",
+        pagesPerFileHint: "Nous créerons un nouveau PDF toutes les N pages.",
+      },
+      extract: {
+        title: "Extraire",
+        preserveMetadata: "Préserver les métadonnées",
+        preserveMetadataHint: "Conserve le titre, l'auteur et les détails.",
+      },
+      crop: {
+        title: "Recadrer",
+        hint: "Sélectionnez les pages à recadrer et définissez les marges.",
+        inputModeLabel: "Méthode",
+        inputModes: {
+          margins: "Définir les marges",
+          manual: "Sélection manuelle",
+        },
+        marginsTitle: "Marges",
+        marginLabels: {
+          top: "Marge supérieure (pts)",
+          right: "Marge droite (pts)",
+          bottom: "Marge inférieure (pts)",
+          left: "Marge gauche (pts)",
+        },
+        marginHint: "72 pts équivaut à environ 1 pouce.",
+        preserveMetadata: "Préserver les métadonnées",
+        preserveMetadataHint: "Conserve le titre, l'auteur et les détails.",
+        manual: {
+          title: "Sélection manuelle",
+          hint: "Faites glisser sur l'aperçu pour définir la zone visible.",
+          loading: "Chargement...",
+          error: "L'aperçu n'a pas pu être chargé.",
+          reset: "Réinitialiser",
+          pagePreview: (pageNumber: number) => `Aperçu page ${pageNumber}`,
+        },
+      },
+      rotate: {
+        title: "Pivoter",
+        hint: "Choisissez la direction et marquez les pages.",
+        rotateRight90: "Pivoter à droite (90°)",
+        rotate180: "Pivoter (180°)",
+        rotateLeft90: "Pivoter à gauche (90°)",
+      },
+      reorder: {
+        title: "Réorganiser",
+        hint: "Faites glisser les vignettes pour modifier l'ordre.",
+      },
+      pdfToImages: {
+        title: "Exportation",
+        formatLabel: "Format",
+        formatHint: "Choisissez PNG pour une qualité sans perte ou JPEG pour des fichiers plus petits.",
+        pngLabel: "PNG (sans perte)",
+        jpegLabel: "JPEG (plus petit)",
+        qualityLabel: "Qualité JPEG",
+        qualityHint: "Une qualité supérieure préserve plus de détails.",
+        dpiLabel: "Rendu DPI",
+        dpiHint: "Un DPI plus élevé augmente la netteté et la taille du fichier.",
+        dpiPresets: {
+          screen: "72 DPI · Écran",
+          balanced: "144 DPI · Équilibré",
+          print: "300 DPI · Impression",
+        },
+        zipLabel: "Regrouper les images dans un ZIP",
+        zipHint: "Téléchargez une seule archive.",
+        baseNameLabel: "Nom de fichier de base",
+        baseNamePlaceholder: "pdflince_pages",
+        baseNameHint: "Laissez vide pour réutiliser le nom du PDF.",
+      },
+      imagesToPdf: {
+        title: "Mise en page",
+        layoutTitle: "Mise en page",
+        fitLabel: "Ajustement de l'image",
+        fitOptions: {
+          contain: "Contenir (afficher l'image entière)",
+          cover: "Couvrir (remplir la page)",
+        },
+        sizeLabel: "Taille de page",
+        sizeOptions: {
+          auto: "Auto (correspond à l'image)",
+          a4: "A4",
+          letter: "Lettre",
+        },
+        orientationLabel: "Orientation",
+        orientationOptions: {
+          auto: "Auto",
+          portrait: "Portrait",
+          landscape: "Paysage",
+        },
+        marginLabel: "Marges (pts)",
+        marginHint: "Ajoute un espace blanc. 72 pts ≈ 1 pouce.",
+        backgroundLabel: "Couleur d'arrière-plan",
+        backgroundHint: "Appliqué derrière les images.",
+      },
+    },
+    cookieBanner: {
+      message: "Nous utilisons des cookies pour analyser le trafic. Nous ne partageons pas vos données.",
+      accept: "Accepter",
+      decline: "Refuser",
+    },
+  },
+  pages: {
+    home: {
+      hero: {
+        title: "PDFLince: Compresser, fusionner et convertir PDF gratuitement",
+        subtitle:
+          "Compressez, fusionnez, divisez, extrayez, pivotez et convertissez des PDF directement dans votre navigateur. Aucun téléchargement, entièrement privé.",
+        badges: [
+          "Compresser PDF",
+          "Fusionner PDF",
+          "Traitement local",
+          "Soutenir PDFLince",
+        ],
+        imageAlt: "Illustration d'un document PDF",
+        ctaLinks: [
+          {
+            label: "PDF en images",
+            href: operationsRoutes.pdfToImages,
+            description: "Exportez au format PNG ou JPEG",
+          },
+          {
+            label: "Images en PDF",
+            href: operationsRoutes.imagesToPdf,
+            description: "Combinez JPG, PNG ou WEBP",
+          },
+        ],
+      },
+      why: {
+        title: "Pourquoi utiliser PDFLince ?",
+        cards: [
+          {
+            title: "Privé par défaut",
+            description:
+              "Vos PDF ne quittent jamais votre appareil. Tout se passe dans votre navigateur.",
+            icon: "🔒",
+          },
+          {
+            title: "Rapide & efficace",
+            description:
+              "Notre moteur local offre une vitesse optimale sans téléchargement cloud.",
+            icon: "⚡",
+          },
+          {
+            title: "Fonctionne partout",
+            description:
+              "Ordinateur, tablette ou téléphone — un navigateur moderne suffit.",
+            icon: "📱",
+          },
+        ],
+      },
+      callout: {
+        title: "Aidez à garder PDFLince gratuit",
+        description:
+          "Chaque don couvre l'hébergement et nous permet de garder l'expérience 100% privée, sans publicité ni suivi.",
+        ctaLabel: "Soutenir le projet",
+        ctaUrl: getRoutePath(locale, "support"),
+        secondaryLabel: "Voir comment nous utilisons les fonds",
+        secondaryUrl: getRoutePath(locale, "support") + "#support-transparency",
+      },
+    },
+    faq: {
+      title: "Questions Fréquentes",
+      intro: "Réponses aux questions les plus courantes sur PDFLince",
+      cta: {
+        title: "Essayez PDFLince maintenant",
+        description:
+          "Fusionnez, compressez, divisez, extrayez, pivotez et réorganisez des PDF en toute confidentialité.",
+        ctaLabel: "Aller à la boîte à outils",
+      },
+    },
+    support: {
+      hero: {
+        eyebrow: "🌱 Projet indépendant",
+        title: "Aidez à garder PDFLince gratuit et privé",
+        subtitle:
+          "PDFLince est un petit projet de passionnés. Votre soutien couvre les serveurs.",
+        highlight: "Juste un petit outil qui respecte votre vie privée.",
+      },
+      reasons: {
+        title: "Pourquoi faire un don ?",
+        cards: [
+          {
+            title: "Garder la gratuité",
+            description:
+              "Les dons nous permettent de garder PDFLince 100% gratuit pour tout le monde.",
+            icon: "💚",
+          },
+          {
+            title: "Améliorations",
+            description:
+              "Votre soutien finance les corrections de bugs et les nouveaux outils.",
+            icon: "✨",
+          },
+          {
+            title: "Protéger la confidentialité",
+            description:
+              "Nous traitons tout localement. Les dons nous permettent de continuer.",
+            icon: "🔒",
+          },
+        ],
+      },
+      tiers: {
+        title: "Donnez ce que vous pouvez",
+        description: "Chaque montant aide. Paiement sécurisé via Stripe.",
+        cards: [
+          {
+            id: "coffee",
+            title: "Acheter un café",
+            amount: "3 €",
+            description: "Couvre l'hébergement pendant quelques semaines.",
+            ctaLabel: "Donner 3 €",
+            ctaHref: "#stripe-checkout-coffee",
+          },
+          {
+            id: "monthly",
+            title: "Soutien mensuel",
+            amount: "10 €/mois",
+            description: "Nous donne du temps chaque semaine pour améliorer PDFLince.",
+            ctaLabel: "Donner 10 €/mois",
+            ctaHref: "#stripe-checkout-monthly",
+            badge: "💙 Merci",
+          },
+          {
+            id: "custom",
+            title: "Montant personnalisé",
+            amount: "Tout montant",
+            description: "Chaque euro compte. Choisissez le montant qui vous convient.",
+            ctaLabel: "Choisir le montant",
+            ctaHref: "#stripe-checkout-custom",
+          },
+        ],
+        note: "Paiements Stripe sécurisés. Annulez les dons récurrents quand vous le souhaitez.",
+      },
+      transparency: {
+        title: "Où va l'argent",
+        items: [
+          "Hébergement et CDN pour que le site reste rapide dans le monde entier",
+          "Temps de développement pour les corrections et les nouvelles fonctionnalités",
+          "Ajustements de conception et d'UX pour garder les choses fluides",
+          "Traductions et documents pour chaque langue prise en charge",
+        ],
+      },
+      faq: {
+        title: "Questions",
+        entries: [
+          {
+            question: "Et si je ne peux pas faire de don ?",
+            answer:
+              "Pas de soucis. PDFLince restera gratuit. Partager l'outil est déjà un soutien incroyable.",
+          },
+          {
+            question: "Aurai-je un reçu ?",
+            answer:
+              "Oui. Stripe vous envoie automatiquement un reçu avec tous les détails.",
+          },
+          {
+            question: "Comment annuler un don récurrent ?",
+            answer:
+              "Gérez-le via votre portail Stripe ou envoyez-nous un e-mail et nous l'annulerons pour vous.",
+          },
+        ],
+      },
+      closing: {
+        title: "Merci d'être ici",
+        description:
+          "Chaque personne qui soutient PDFLince aide à maintenir en vie une boîte à outils PDF utile.",
+        ctaLabel: "Envoyer un e-mail à l'équipe",
+        ctaHref: "mailto:info@pdflince.com?subject=Hello%20PDFLince%20team",
+      },
+      legalNotice: {
+        title: "Notes légales et transparence",
+        points: [
+          "PDFLince est un projet personnel indépendant géré par une petite équipe bénévole.",
+          "Les contributions sont volontaires et aident à couvrir l'hébergement et le temps de développement.",
+          "Les paiements ne sont pas des dons de bienfaisance; Stripe enverra un reçu automatique.",
+          "Le service est fourni tel quel sans garantie. Des questions ? info@pdflince.com.",
+        ],
+      },
+    },
+  },
+  faqs: faqsFr,
+  operations: operationsFr,
+};

--- a/src/i18n/dictionaries/fr/operations.ts
+++ b/src/i18n/dictionaries/fr/operations.ts
@@ -1,0 +1,621 @@
+import { OperationContent } from "../operation-types";
+import { OperationKey } from "../../../types/operations";
+
+const operationsFrContent: Record<OperationKey, OperationContent> = {
+  compress: {
+    key: "compress",
+    slug: "compresser",
+    mode: "compress",
+    meta: {
+      title: "Compresser un PDF en ligne gratuitement | Réduire la taille | PDFLince",
+      description:
+        "Réduisez efficacement la taille du fichier PDF sans perte de qualité. Compression gratuite et privée directement dans votre navigateur.",
+      keywords: [
+        "compresser pdf",
+        "réduire taille pdf",
+        "optimiser pdf",
+        "compresseur pdf",
+        "pdf léger",
+      ],
+      ogTitle: "Compresser des PDF sans perdre en qualité | PDFLince",
+      ogDescription:
+        "Déposez votre fichier, choisissez le niveau de compression optimal et téléchargez un PDF beaucoup plus petit en quelques secondes — en toute sécurité, sans téléchargement sur un serveur.",
+      ogImageAlt: "Interface de l'outil de compression PDFLince",
+    },
+    hero: {
+      title: "Compresser un PDF en ligne avec des résultats clairs",
+      description:
+        "Réduisez la taille du document pour respecter les limites des e-mails, des plateformes LMS ou des procédures publiques tout en gardant chaque page lisible.",
+      bulletPoints: [
+        "Traitement 100 % local — vos fichiers ne quittent jamais le navigateur",
+        "Choisissez une compression basique, moyenne ou agressive selon vos objectifs",
+        "Préservez les métadonnées et la structure du document lorsque vous en avez besoin",
+      ],
+      imageAlt: "Flux de travail de compression PDF dans PDFLince",
+    },
+    benefitsTitle: "Pourquoi compresser des PDF avec PDFLince",
+    benefits: [
+      {
+        title: "Qualité équilibrée",
+        description:
+          "Notre moteur de compression évalue chaque ressource pour offrir la plus grande réduction sans brouiller le texte ou les graphiques.",
+      },
+      {
+        title: "Prêt pour les soumissions",
+        description:
+          "Produisez des fichiers qui respectent les limites de téléchargement strictes dans les portails gouvernementaux, les universités ou les flux de travail d'entreprise.",
+      },
+      {
+        title: "Confidentialité dès la conception",
+        description:
+          "Évitez les téléchargements sur serveur et les fuites de données afin de vous conformer aux politiques de confidentialité internes sans effort.",
+      },
+    ],
+    howTo: {
+      title: "Comment compresser un PDF avec PDFLince",
+      steps: [
+        "Cliquez sur « Télécharger vos fichiers » et choisissez le PDF que vous souhaitez optimiser.",
+        "Choisissez le niveau de compression et ajustez les options avancées comme la conservation des métadonnées.",
+        "Appuyez sur « Traiter » et téléchargez le document compressé en quelques secondes.",
+      ],
+      note:
+        "Vous travaillez avec plusieurs rapports ? Compressez-les un par un sans limites quotidiennes ni filigranes.",
+    },
+    useCasesTitle: "Quand la compression est utile",
+    useCases: [
+      "Envoyez des contrats, des factures ou des manuels par e-mail sans atteindre les limites de pièces jointes.",
+      "Téléchargez des travaux sur Moodle, Canvas ou tout autre LMS qui impose une limite stricte de taille de fichier.",
+      "Réduisez la taille des thèses, des catalogues ou des documents de recherche pour améliorer la vitesse de téléchargement.",
+      "Archivez des dossiers dans le cloud en économisant du stockage sans perdre de détails importants.",
+    ],
+  },
+  imagesToPdf: {
+    key: "imagesToPdf",
+    slug: "creer-pdf-depuis-images",
+    mode: "imagesToPdf",
+    meta: {
+      title: "Créer un PDF à partir d'images | JPG, PNG en PDF | PDFLince",
+      description:
+        "Créez un PDF professionnel à partir de vos images. Organisez les photos, personnalisez la mise en page et générez votre document localement dans votre navigateur.",
+      keywords: [
+        "images en pdf",
+        "jpg en pdf",
+        "png en pdf",
+        "webp en pdf",
+        "créer pdf depuis images",
+      ],
+      ogTitle: "Créez un PDF net à partir de vos images | PDFLince",
+      ogDescription:
+        "Faites glisser vos images à leur place, définissez les paramètres de mise en page et exportez un fichier PDF prêt à imprimer — sans téléchargement ni filigrane.",
+      ogImageAlt: "Création d'un PDF à partir d'images dans PDFLince",
+    },
+    hero: {
+      title: "Créer un PDF soigné à partir d'images",
+      description:
+        "Regroupez des numérisations, des photos ou des graphiques dans un seul PDF prêt à être partagé avec des équipes, des étudiants ou des clients.",
+      bulletPoints: [
+        "Faites glisser pour définir l'ordre de chaque page",
+        "Choisissez la taille de page, l'orientation et les marges qui conviennent à l'impression ou à la révision à l'écran",
+        "Définissez une couleur d'arrière-plan unie pour éviter une transparence inattendue",
+      ],
+      imageAlt: "Flux de travail des images en PDF",
+    },
+    benefitsTitle: "Pourquoi assembler des PDF à partir d'images avec PDFLince",
+    benefits: [
+      {
+        title: "Mise en page cohérente",
+        description:
+          "Alignez des formats d'image mixtes dans un PDF unifié sans surprises d'étirement ou de recadrage.",
+      },
+      {
+        title: "Prêt pour l'impression et la révision",
+        description:
+          "Ajustez les marges, l'orientation et la couleur d'arrière-plan pour que le PDF exporté soit beau sur papier et sur les écrans.",
+      },
+      {
+        title: "Traitement sécurisé",
+        description:
+          "Toutes les conversions se font localement dans votre navigateur, ce qui est sûr pour les numérisations de cartes d'identité, de reçus ou de matériel scolaire.",
+      },
+    ],
+    howTo: {
+      title: "Comment convertir des images en PDF",
+      steps: [
+        "Ajoutez les images que vous souhaitez inclure. Réorganisez-les pour que la séquence corresponde à votre document final.",
+        "Ajustez le mode d'ajustement, la taille de la page, l'orientation et les marges en fonction de vos besoins de sortie.",
+        "Cliquez sur « Créer PDF » pour télécharger un document compilé prêt à être partagé ou archivé.",
+      ],
+      note:
+        "De gros lots ? Compressez le PDF résultant ou divisez-le ensuite sans télécharger à nouveau vos images.",
+    },
+    useCasesTitle: "Excellentes utilisations des conversions d'image en PDF",
+    useCases: [
+      "Combinez des feuilles de calcul numérisées ou des copies d'examen avant de les renvoyer aux étudiants.",
+      "Préparez les reçus de frais dans un seul PDF au lieu de dizaines de pièces jointes.",
+      "Créez des lookbooks ou des catalogues à partir d'exportations de conception en quelques secondes.",
+      "Regroupez des preuves photographiques ou des clichés d'inspection dans un seul document pour les parties prenantes.",
+    ],
+  },
+  merge: {
+    key: "merge",
+    slug: "fusionner",
+    mode: "merge",
+    meta: {
+      title: "Fusionner PDF | Combiner plusieurs PDF gratuitement | PDFLince",
+      description:
+        "Combinez plusieurs fichiers PDF en un seul document organisé sans limite de page. Glissez, réorganisez et téléchargez votre fichier fusionné instantanément.",
+      keywords: [
+        "fusionner pdf",
+        "combiner pdf",
+        "joindre fichiers pdf",
+        "fusion de pdf",
+        "fusionner documents",
+      ],
+      ogTitle: "Fusionnez plusieurs PDF en quelques secondes | PDFLince",
+      ogDescription:
+        "Organisez vos documents dans l'ordre parfait, ajustez les paramètres et téléchargez un fichier PDF unifié sans jamais télécharger vos données.",
+      ogImageAlt: "Combinaison de plusieurs PDF dans PDFLince",
+    },
+    hero: {
+      title: "Fusionner des PDF en ligne — rapide et sécurisé",
+      description:
+        "Créez un fichier soigné avec des contrats, des notes de cours ou des documents de politique prêts à être envoyés, signés ou archivés.",
+      bulletPoints: [
+        "Glissez et déposez pour contrôler l'ordre final",
+        "Pas de limites cachées — fusionnez de longs documents gratuitement",
+        "Conservez les signets et les métadonnées lorsque vous en avez besoin",
+      ],
+      imageAlt: "Fusion de documents PDF",
+    },
+    benefitsTitle: "Avantages de la fusion avec PDFLince",
+    benefits: [
+      {
+        title: "Livraison cohérente",
+        description:
+          "Livrez du matériel dans un seul fichier avec des numéros de page continus et un formatage unifié.",
+      },
+      {
+        title: "Gagnez du temps",
+        description:
+          "Évitez les éditeurs de bureau lourds. Faites glisser les fichiers, organisez-les et téléchargez un document prêt à être partagé.",
+      },
+      {
+        title: "Privé et anonyme",
+        description:
+          "Nous ne stockons aucune copie et ne demandons pas de données personnelles, ce qui est parfait pour les informations confidentielles.",
+      },
+    ],
+    howTo: {
+      title: "Comment fusionner des PDF avec PDFLince",
+      steps: [
+        "Cliquez sur « Télécharger vos fichiers » et sélectionnez au moins deux PDF.",
+        "Utilisez les flèches ou faites glisser chaque fichier pour définir la séquence finale.",
+        "Choisissez vos préférences de signet et appuyez sur « Traiter » pour télécharger le PDF fusionné.",
+      ],
+      note:
+        "Besoin d'ajouter plus de fichiers plus tard ? Déposez-les à tout moment sans recommencer.",
+    },
+    useCasesTitle: "Quand fusionner des PDF",
+    useCases: [
+      "Préparez un dossier avec des annexes, des devis et des conditions commerciales.",
+      "Envoyez plusieurs factures mensuelles dans un seul fichier aux départements financiers.",
+      "Regroupez les notes numérisées et les présentations dans un seul PDF pour les étudiants.",
+      "Créez des packages juridiques complets prêts pour les signatures électroniques.",
+    ],
+  },
+  split: {
+    key: "split",
+    slug: "diviser",
+    mode: "split",
+    meta: {
+      title: "Diviser un PDF par pages ou chapitres | Outil gratuit | PDFLince",
+      description:
+        "Séparez votre PDF en plusieurs fichiers par plages de pages ou chapitres spécifiques. Profitez d'un contrôle total sur la structure de votre document.",
+      keywords: [
+        "diviser pdf",
+        "séparer pdf",
+        "diviser pdf par pages",
+        "diviseur pdf",
+        "couper pdf",
+      ],
+      ogTitle: "Divisez vos PDF avec précision | PDFLince",
+      ogDescription:
+        "Choisissez exactement comment diviser votre document, générez autant de fichiers individuels que nécessaire et téléchargez-les instantanément.",
+      ogImageAlt: "Division d'un PDF dans PDFLince",
+    },
+    hero: {
+      title: "Diviser des PDF par pages ou segments",
+      description:
+        "Extrayez des chapitres, des annexes ou des sections spécifiques dans des fichiers autonomes prêts à être partagés.",
+      bulletPoints: [
+        "Configurez les divisions par nombre de pages ou par taille de fichier",
+        "Produisez plusieurs PDF en une seule étape de traitement",
+        "Travaillez sans limites de pages ni filigranes",
+      ],
+      imageAlt: "Flux de travail de division de PDF",
+    },
+    benefitsTitle: "Ce que vous apporte la division avec PDFLince",
+    benefits: [
+      {
+        title: "Contrôle des informations partagées",
+        description:
+          "Ne livrez que la partie pertinente d'un document sans exposer de sections sensibles.",
+      },
+      {
+        title: "Livraison évolutive",
+        description:
+          "Générez plusieurs fichiers à la fois et téléchargez-les automatiquement pour l'archivage ou le transfert.",
+      },
+      {
+        title: "Ajustements avancés",
+        description:
+          "Créez des lots, insérez des séparateurs ou définissez des formats de sortie qui correspondent à votre flux de travail.",
+      },
+    ],
+    howTo: {
+      title: "Comment diviser un PDF avec PDFLince",
+      steps: [
+        "Téléchargez le PDF que vous souhaitez segmenter à partir de votre appareil.",
+        "Choisissez si vous souhaitez diviser par un nombre fixe de pages ou par taille de fichier.",
+        "Appuyez sur « Traiter » et téléchargez automatiquement les documents nouvellement générés.",
+      ],
+      note:
+        "PDFLince télécharge le premier fichier immédiatement et enregistre le reste sur votre appareil sans étapes supplémentaires.",
+    },
+    useCasesTitle: "Scénarios typiques pour diviser des PDF",
+    useCases: [
+      "Publiez chaque chapitre d'un livre numérique dans un cours en ligne.",
+      "Séparez les annexes qui doivent être envoyées par différents canaux.",
+      "Extrayez des résumés trimestriels à partir de rapports financiers volumineux.",
+      "Préparez des lots compacts pour les clients sans exposer la documentation interne.",
+    ],
+  },
+  extract: {
+    key: "extract",
+    slug: "extraire",
+    mode: "extract",
+    meta: {
+      title: "Extraire des pages PDF | Sauvegarder pages sélectionnées | PDFLince",
+      description:
+        "Sélectionnez des pages spécifiques dans n'importe quel PDF et créez instantanément un nouveau document sur mesure. Traitement privé et illimité.",
+      keywords: [
+        "extraire pages pdf",
+        "sauvegarder pages pdf",
+        "sélectionner pages pdf",
+        "extracteur de pages pdf",
+        "créer nouveau pdf",
+      ],
+      ogTitle: "Extrayez uniquement les pages dont vous avez besoin | PDFLince",
+      ogDescription:
+        "Marquez les pages pertinentes que vous souhaitez conserver, générez un nouveau fichier PDF en quelques secondes et assurez la sécurité de vos données.",
+      ogImageAlt: "Sélection de pages PDF dans PDFLince",
+    },
+    hero: {
+      title: "Extraire des pages PDF spécifiques",
+      description:
+        "Assemblez des documents sur mesure en ne conservant que les pages dont vous avez besoin de partager ou d'archiver.",
+      bulletPoints: [
+        "Prévisualisez les vignettes et marquez les pages individuelles",
+        "Conservez les numéros de page d'origine ou créez de nouvelles sections",
+        "Téléchargez instantanément le PDF résultant sans attendre",
+      ],
+      imageAlt: "Extraction de pages d'un PDF",
+    },
+    benefitsTitle: "Avantages de l'extraction de pages avec PDFLince",
+    benefits: [
+      {
+        title: "Documents plus pertinents",
+        description:
+          "Partagez uniquement des informations utiles avec votre équipe ou vos clients et évitez les données redondantes.",
+      },
+      {
+        title: "Contrôle total dans le navigateur",
+        description:
+          "Sélectionnez, prévisualisez et vérifiez chaque page sans logiciel lourd ni connexions stables.",
+      },
+      {
+        title: "Des résultats propres",
+        description:
+          "Le nouveau PDF conserve la qualité et les métadonnées en fonction des options que vous définissez.",
+      },
+    ],
+    howTo: {
+      title: "Comment extraire des pages avec PDFLince",
+      steps: [
+        "Téléchargez le PDF et choisissez le fichier avec lequel vous souhaitez travailler.",
+        "Sélectionnez les pages dont vous avez besoin dans la grille de vignettes.",
+        "Cliquez sur « Traiter » pour télécharger un PDF avec les pages sélectionnées.",
+      ],
+      note:
+        "Vous pouvez combiner l'extraction avec d'autres opérations telles que la fusion ou la compression lors de sessions séparées.",
+    },
+    useCasesTitle: "Idées pour l'extraction de pages",
+    useCases: [
+      "Partagez le chapitre assigné d'un manuel avec votre équipe.",
+      "Envoyez des pages de prêt hypothécaire ou de contrat spécifiques pour un examen juridique.",
+      "Assemblez des dossiers personnalisés avec uniquement les informations pertinentes pour chaque client.",
+      "Enregistrez des copies des pages de formulaire ou des reçus que vous devez archiver.",
+    ],
+  },
+  crop: {
+    key: "crop",
+    slug: "recadrer",
+    mode: "crop",
+    meta: {
+      title: "Recadrer des pages PDF | Ajuster marges | PDFLince",
+      description:
+        "Recadrez des pages PDF et réduisez les marges excédentaires directement dans votre navigateur. Sélectionnez les pages, définissez la zone de recadrage.",
+      keywords: [
+        "recadrer pdf",
+        "recadrer pdf en ligne",
+        "ajuster marges pdf",
+        "couper pages pdf",
+        "outil de recadrage pdf",
+        "recadrer pdf gratuit",
+        "supprimer espace blanc pdf",
+      ],
+      ogTitle: "Recadrez des pages PDF localement dans votre navigateur | PDFLince",
+      ogDescription:
+        "Réduisez les marges blanches et concentrez chaque page sur le contenu dont vous avez besoin, avec un traitement privé sur votre appareil.",
+      ogImageAlt: "Recadrage de pages PDF dans PDFLince",
+    },
+    hero: {
+      title: "Recadrer les pages PDF et réduire les marges",
+      description:
+        "Supprimez l'espace blanc supplémentaire ou resserrez la zone visible des pages sélectionnées sans envoyer le document nulle part.",
+      bulletPoints: [
+        "Sélectionnez uniquement les pages que vous souhaitez recadrer",
+        "Réduisez les marges supérieure, droite, inférieure et gauche avec des valeurs de points précises",
+        "Gardez le flux de travail entièrement local avec un traitement sans serveur",
+      ],
+      imageAlt: "Flux de travail de recadrage PDF",
+    },
+    benefitsTitle: "Pourquoi recadrer des PDF avec PDFLince",
+    benefits: [
+      {
+        title: "Pages plus propres",
+        description:
+          "Réduisez les bordures blanches distrayantes et concentrez chaque page sur le contenu important.",
+      },
+      {
+        title: "Édition sélective",
+        description:
+          "Ne recadrez que les pages qui nécessitent un ajustement au lieu de reconstruire l'ensemble du document.",
+      },
+      {
+        title: "Privé par défaut",
+        description:
+          "Chaque recadrage s'exécute dans votre navigateur, ce qui est plus sûr pour les factures, les numérisations et les rapports internes.",
+      },
+    ],
+    howTo: {
+      title: "Comment recadrer des pages PDF avec PDFLince",
+      steps: [
+        "Téléchargez le PDF et choisissez le fichier dont vous souhaitez recadrer les pages.",
+        "Sélectionnez les pages à modifier et définissez les marges de recadrage.",
+        "Cliquez sur Traiter pour télécharger un nouveau PDF avec les limites de page mises à jour.",
+      ],
+      note:
+        "Si différents groupes de pages nécessitent des recadrages différents, exécutez l'étape de recadrage plusieurs fois.",
+    },
+    useCasesTitle: "Quand le recadrage d'un PDF aide",
+    useCases: [
+      "Coupez les bordures du scanner des formulaires, des reçus ou des documents signés.",
+      "Supprimez les marges blanches supplémentaires avant l'impression ou la combinaison de fichiers.",
+      "Standardisez les pages exportées de différents outils avec des bordures incohérentes.",
+      "Préparez des cadres de page plus serrés avant de partager des manuels, des rapports ou du matériel d'étude.",
+    ],
+  },
+  rotate: {
+    key: "rotate",
+    slug: "faire-pivoter",
+    mode: "rotate",
+    meta: {
+      title: "Faire pivoter des pages PDF | Tourner les pages | PDFLince",
+      description:
+        "Faites pivoter les pages PDF sélectionnées de 90 ou 180 degrés directement dans votre navigateur. Privé, gratuit et entièrement local.",
+      keywords: [
+        "faire pivoter pdf",
+        "tourner pages pdf",
+        "rotation pdf",
+        "corriger pdf de côté",
+        "pivoter page pdf",
+      ],
+      ogTitle: "Faites pivoter des pages PDF en quelques secondes | PDFLince",
+      ogDescription:
+        "Sélectionnez les pages qui ont besoin d'une nouvelle orientation, choisissez 90 ou 180 degrés, et téléchargez le PDF corrigé sans rien télécharger.",
+      ogImageAlt: "Rotation de pages PDF dans PDFLince",
+    },
+    hero: {
+      title: "Faire pivoter des pages PDF sans perte de qualité",
+      description:
+        "Corrigez les numérisations de côté, les exportations à l'envers ou les orientations de page mixtes en quelques clics.",
+      bulletPoints: [
+        "Faites pivoter uniquement les pages que vous sélectionnez",
+        "Choisissez 90 degrés à droite, 180 degrés ou 90 degrés à gauche",
+        "Gardez tout dans votre navigateur sans téléchargements ni salles d'attente",
+      ],
+      imageAlt: "Flux de travail de rotation de page PDF",
+    },
+    benefitsTitle: "Pourquoi faire pivoter des pages avec PDFLince",
+    benefits: [
+      {
+        title: "Corrections précises",
+        description:
+          "Ajustez uniquement les pages qui ont besoin d'aide, ce qui est parfait pour les lots de numérisation mixtes.",
+      },
+      {
+        title: "Nettoyage rapide",
+        description:
+          "Corrigez l'orientation de la page en quelques secondes sans rouvrir le fichier dans un éditeur lourd.",
+      },
+      {
+        title: "Privé par défaut",
+        description:
+          "Les documents sensibles restent sur votre appareil car chaque rotation s'exécute localement.",
+      },
+    ],
+    howTo: {
+      title: "Comment faire pivoter des pages PDF",
+      steps: [
+        "Téléchargez le PDF et choisissez le fichier dont vous souhaitez corriger les pages.",
+        "Sélectionnez les pages à faire pivoter et choisissez 90 degrés à droite, 180 degrés ou 90 degrés à gauche.",
+        "Cliquez sur Traiter pour télécharger un nouveau PDF avec l'orientation mise à jour.",
+      ],
+      note:
+        "Besoin de plus de nettoyage ensuite ? Vous pouvez toujours réorganiser, extraire ou compresser le PDF corrigé.",
+    },
+    useCasesTitle: "Quand la rotation de la page aide",
+    useCases: [
+      "Corrigez les contrats ou formulaires numérisés qui ont été capturés de côté.",
+      "Retournez les pages à l'envers dans les rapports assemblés à partir de différentes sources.",
+      "Corrigez les notes de cours ou les manuels avant de les partager avec les étudiants.",
+      "Nettoyez les PDF d'archives pour que chaque page soit confortable à lire à l'écran.",
+    ],
+  },
+  reorder: {
+    key: "reorder",
+    slug: "reorganiser",
+    mode: "reorder",
+    meta: {
+      title: "Réorganiser les pages PDF | Changer l'ordre | PDFLince",
+      description:
+        "Réorganisez facilement vos pages PDF avec une simple interface glisser-déposer. Corrigez l'ordre des documents et enregistrez instantanément.",
+      keywords: [
+        "réorganiser pdf",
+        "changer ordre page pdf",
+        "organiser pdf",
+        "trier pages pdf",
+      ],
+      ogTitle: "Organisez des pages PDF sans réinstaller de logiciel | PDFLince",
+      ogDescription:
+        "Déplacez les pages à leur place, corrigez les erreurs de tri et téléchargez votre document PDF parfaitement organisé.",
+      ogImageAlt: "Réorganisation de pages PDF",
+    },
+    hero: {
+      title: "Réorganiser les pages PDF avec le glisser-déposer",
+      description:
+        "Corrigez la séquence des factures numérisées, des présentations ou des longs rapports en quelques secondes.",
+      bulletPoints: [
+        "Les grandes vignettes vous aident à éviter les erreurs",
+        "Faites glisser les pages et confirmez le nouvel ordre instantanément",
+        "Exportez le PDF réorganisé sans perdre les signets ou les liens internes",
+      ],
+      imageAlt: "Interface de commande de page",
+    },
+    benefitsTitle: "Pourquoi réorganiser avec PDFLince",
+    benefits: [
+      {
+        title: "Flux de travail plus rapides",
+        description:
+          "Corrigez les numérisations désordonnées sans renumériser ni installer d'éditeurs complexes.",
+      },
+      {
+        title: "Précision visuelle",
+        description:
+          "Les vignettes vous permettent de valider chaque page avant d'exporter la nouvelle séquence.",
+      },
+      {
+        title: "Aucune trace",
+        description:
+          "Tout se passe sur votre appareil, ce qui est idéal pour les documents sensibles.",
+      },
+    ],
+    howTo: {
+      title: "Comment réorganiser les pages avec PDFLince",
+      steps: [
+        "Téléchargez le PDF et choisissez le fichier que vous souhaitez modifier.",
+        "Faites glisser chaque vignette jusqu'à ce que l'ordre soit correct.",
+        "Appuyez sur « Traiter » pour télécharger le document avec sa nouvelle séquence.",
+      ],
+      note:
+        "Continuez à ajuster l'ordre même après une exportation sans télécharger à nouveau le fichier.",
+    },
+    useCasesTitle: "Quand réorganiser un PDF",
+    useCases: [
+      "Alignez les devis, les annexes et les signatures avant l'envoi.",
+      "Préparez des présentations imprimées avec la bonne séquence.",
+      "Corrigez les pages en double ou inversées après un grand lot de numérisation.",
+      "Actualisez les manuels en réutilisant le contenu existant sans tout reconcevoir.",
+    ],
+  },
+  pdfToImages: {
+    key: "pdfToImages",
+    slug: "pdf-en-images",
+    mode: "pdfToImages",
+    meta: {
+      title: "Convertir des PDF en images | Exportation PNG ou JPEG | PDFLince",
+      description:
+        "Convertissez chaque page de votre PDF en images PNG ou JPEG de haute qualité. Choisissez votre résolution et téléchargez sous forme de ZIP.",
+      keywords: [
+        "pdf en images",
+        "exporter pages pdf",
+        "pdf en png",
+        "pdf en jpeg",
+        "télécharger pdf comme images",
+      ],
+      ogTitle: "Exportez des pages PDF sous forme d'images nettes | PDFLince",
+      ogDescription:
+        "Rendez chaque page sous forme d'image nette directement dans votre navigateur. Ajustez la qualité et obtenez instantanément une archive ZIP.",
+      ogImageAlt: "PDFLince exportant des pages PDF en images",
+    },
+    hero: {
+      title: "Convertir des pages PDF en PNG ou JPEG",
+      description:
+        "Produisez des images nettes de chaque page pour des diaporamas, des révisions ou des transferts de conception.",
+      bulletPoints: [
+        "Sélectionnez PNG ou JPEG et contrôlez le DPI d'exportation",
+        "Regroupez tout dans un seul ZIP ou téléchargez page par page",
+        "Rendu local uniquement — pas de téléchargements, pas de traces",
+      ],
+      imageAlt: "Flux de travail de PDF vers des images",
+    },
+    benefitsTitle: "Pourquoi exporter des PDF avec PDFLince",
+    benefits: [
+      {
+        title: "Qualité prête pour la présentation",
+        description:
+          "Choisissez la résolution qui correspond à vos diapositives sans deviner si les pages seront assez nettes.",
+      },
+      {
+        title: "Téléchargements flexibles",
+        description:
+          "Conservez un ZIP bien ordonné pour les documents longs ou déclenchez des téléchargements individuels.",
+      },
+      {
+        title: "Privé dès la conception",
+        description:
+          "Le rendu s'effectue dans votre navigateur, de sorte que les documents confidentiels n'atteignent jamais de serveurs tiers.",
+      },
+    ],
+    howTo: {
+      title: "Comment convertir un PDF en images",
+      steps: [
+        "Téléchargez le PDF que vous souhaitez convertir.",
+        "Choisissez PNG ou JPEG, ajustez le DPI et décidez s'il faut regrouper les résultats dans un ZIP.",
+        "Cliquez sur « Exporter images » pour télécharger l'archive.",
+      ],
+      note:
+        "Besoin de quelques pages seulement ? Divisez ou extrayez d'abord, puis exportez en images.",
+    },
+    useCasesTitle: "Quand une conversion de PDF en image aide",
+    useCases: [
+      "Partagez des aperçus statiques des approbations de conception.",
+      "Intégrez des pages PDF uniques dans des plates-formes CMS ou des diaporamas.",
+      "Créez des documents d'images pour tablettes ou liseuses qui ont du mal avec de gros PDF.",
+      "Documentez des flux de travail de révision qui nécessitent des captures d'écran.",
+    ],
+  },
+};
+
+export const operationsFr: Record<OperationKey, OperationContent> = {
+  merge: operationsFrContent.merge,
+  compress: operationsFrContent.compress,
+  split: operationsFrContent.split,
+  extract: operationsFrContent.extract,
+  crop: operationsFrContent.crop,
+  rotate: operationsFrContent.rotate,
+  reorder: operationsFrContent.reorder,
+  pdfToImages: operationsFrContent.pdfToImages,
+  imagesToPdf: operationsFrContent.imagesToPdf,
+};

--- a/src/i18n/dictionaries/it/index.ts
+++ b/src/i18n/dictionaries/it/index.ts
@@ -387,6 +387,12 @@ export const itDictionary: Dictionary = {
           "Non siamo riusciti a completare l’operazione. Controlla i file e riprova.",
         retryLabel: "Riprova",
         closeLabel: "Chiudi",
+        sharePrompt: {
+          dialogMessage: "PDFLince è completamente gratuito e rispetta la tua privacy. Aiutaci a mantenerlo tale condividendolo con un collega.",
+          shareText: "Ho appena usato PDFLince per gestire i miei PDF. È un toolkit gratuito, veloce e completamente privato per dividere, comprimere, unire e convertire PDF direttamente nel browser. Perfetto per i documenti sensibili!",
+          actionLabel: "Condividi",
+          copiedLabel: "Copiato!",
+        },
       },
 
       compressionTotal: {

--- a/src/i18n/dictionaries/pt/index.ts
+++ b/src/i18n/dictionaries/pt/index.ts
@@ -339,6 +339,12 @@ export const ptDictionary: Dictionary = {
         errorDescription: "Não foi possível concluir a operação. Verifique os arquivos e tente outra vez.",
         retryLabel: "Tentar novamente",
         closeLabel: "Fechar",
+        sharePrompt: {
+          dialogMessage: "O PDFLince é totalmente gratuito e respeita a sua privacidade. Ajude-nos a mantê-lo assim compartilhando-o com um colega.",
+          shareText: "Acabei de usar o PDFLince para gerenciar meus PDFs. É uma ferramenta gratuita, rápida e totalmente privada para dividir, comprimir, juntar e converter PDFs direto no navegador. Perfeita para documentos sensíveis!",
+          actionLabel: "Compartilhar",
+          copiedLabel: "Copiado!",
+        },
       },
       compressionTotal: {
         title: "Economia total (todos os arquivos)",

--- a/src/i18n/get-dictionary.ts
+++ b/src/i18n/get-dictionary.ts
@@ -4,6 +4,7 @@ import { enDictionary } from "./dictionaries/en";
 import { ptDictionary } from "./dictionaries/pt";
 import { deDictionary } from "./dictionaries/de";
 import { itDictionary } from "./dictionaries/it";
+import { frDictionary } from "./dictionaries/fr";
 import type { Dictionary } from "./dictionaries/dictionary-types";
 
 const dictionaries: Record<Locale, Dictionary> = {
@@ -12,6 +13,7 @@ const dictionaries: Record<Locale, Dictionary> = {
   pt: ptDictionary,
   de: deDictionary,
   it: itDictionary,
+  fr: frDictionary,
 };
 
 export function getDictionary(locale: Locale = DEFAULT_LOCALE): Dictionary {

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -73,6 +73,17 @@ const localeOperationSlugMap: Record<Locale, Record<OperationKey, string>> = {
     pdfToImages: "",
     imagesToPdf: "",
   },
+  fr: {
+    compress: "",
+    merge: "",
+    split: "",
+    extract: "",
+    crop: "",
+    rotate: "",
+    reorder: "",
+    pdfToImages: "",
+    imagesToPdf: "",
+  },
 };
 
 const localeOperationSlugLookup: Record<Locale, Record<string, OperationKey>> = {
@@ -81,6 +92,7 @@ const localeOperationSlugLookup: Record<Locale, Record<string, OperationKey>> = 
   pt: {},
   de: {},
   it: {},
+  fr: {},
 };
 
 const trimLeadingSlash = (path: string) => (path.startsWith("/") ? path.slice(1) : path);
@@ -157,4 +169,33 @@ export function getLocalizedAlternateMap(identifier: RouteIdentifier): Record<Lo
 
 export function getRouteMap() {
   return routeMap;
+}
+
+/**
+ * Flat lookup: URL slug segment → OperationKey across ALL locales.
+ * Built dynamically from the route map so it never goes stale.
+ * Used by BreadcrumbSchema to resolve the last path segment
+ * into an operation key for structured data labels.
+ */
+export function buildGlobalSlugToOperationMap(): Record<string, OperationKey> {
+  const map: Record<string, OperationKey> = {};
+  for (const [slug, opKey] of Object.values(localeOperationSlugLookup).flatMap(Object.entries)) {
+    map[slug] = opKey;
+  }
+  return map;
+}
+
+/**
+ * Set of all FAQ URL segments across all locales (e.g. "faq", "preguntas-frecuentes", etc.).
+ * Built dynamically from the route map.
+ */
+export function buildFaqSegmentSet(): Set<string> {
+  const segments = new Set<string>();
+  const faqRoutes = routeMap.faq;
+  for (const path of Object.values(faqRoutes)) {
+    const parts = path.split("/").filter(Boolean);
+    const lastSegment = parts[parts.length - 1];
+    if (lastSegment) segments.add(lastSegment);
+  }
+  return segments;
 }

--- a/tests/e2e/ui-refinements.spec.ts
+++ b/tests/e2e/ui-refinements.spec.ts
@@ -61,6 +61,9 @@ test.describe('UI Refinements', () => {
         // 8. Close the ProcessingStatusDialog modal (it overlays the page)
         // Press Escape to dismiss — avoids strict mode with 2 "Cerrar" buttons
         await page.keyboard.press('Escape');
+        
+        // Wait for the dialog to fully unmount to avoid intercepting clicks
+        await expect(page.getByRole('dialog')).not.toBeVisible();
 
         // 9. Clear All — reset the file list
         await clearAllButton.click();


### PR DESCRIPTION
## Description

This PR introduces full French localization for the application and implements the **Post-Download Share Vector**, designed to drive organic growth by prompting users to share PDFLince at their moment of highest satisfaction.

**Key Implementations:**
*   **Full French Localization:** Added comprehensive French translations across the entire application, including the main dictionary (`fr/index.ts`), FAQs (`fr/faqs.ts`), operations metadata (`fr/operations.ts`), and corresponding routing layouts.
*   **Web Share API Integration:** Added a native share button to `ProcessingStatusDialog.tsx`. If the browser supports it, it opens the native share sheet. If not, it falls back to a graceful `navigator.clipboard.writeText()` action with a temporary "Copied!" state.
*   **Localized Share Prompts:** Expanded `dictionary-types.ts` and updated all 6 language dictionaries (EN, ES, FR, DE, PT, IT) with high-converting, value-driven copy targeting users' most popular actions (split, compress, merge, convert).
*   **README Cleanup:** Removed emojis from `README.md` to establish a more professional, open-source aesthetic.

Fixes # (Leave blank or add issue number if you have one tracked)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?

- [x] **Localization Verification:** Verified that all French routes (`/fr`, `/fr/faq`, etc.) render correctly without missing dictionary keys, and that the hreflang tags point to the correct localized URLs.
- [x] **Web Share API Verification:** Tested the UI rendering of the Share button upon successful PDF processing. Verified that `navigator.share` correctly receives the `title`, `text`, and `url` parameters.
- [x] **Fallback Clipboard Verification:** Verified that environments lacking Web Share API support correctly trigger the clipboard copy mechanism and temporarily display the localized "Copied!" label.
- [x] **Type Safety & Build Integrity:** Ran `npm run build` locally. Verified that the `ProcessingStatusDialogProps` strictly adhere to the new `SharePromptStrings` interface without throwing ESLint or TS compilation errors.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes