### PR TITLE
fix: remove duplicate routes, and expand metadata

### DIFF
--- a/src/app/(es)/(operations)/comprimir/page.tsx
+++ b/src/app/(es)/(operations)/comprimir/page.tsx
@@ -1,8 +1,0 @@
-import { buildOperationMetadata, buildOperationPage } from "../../../(helpers)/operation-handlers";
-import { DEFAULT_LOCALE } from "../../../../i18n/config";
-
-const LOCALE = DEFAULT_LOCALE;
-const OPERATION_KEY = "compress" as const;
-
-export const generateMetadata = buildOperationMetadata(LOCALE, OPERATION_KEY);
-export default buildOperationPage(LOCALE, OPERATION_KEY);

--- a/src/app/(es)/(operations)/dividir/page.tsx
+++ b/src/app/(es)/(operations)/dividir/page.tsx
@@ -1,8 +1,0 @@
-import { buildOperationMetadata, buildOperationPage } from "../../../(helpers)/operation-handlers";
-import { DEFAULT_LOCALE } from "../../../../i18n/config";
-
-const LOCALE = DEFAULT_LOCALE;
-const OPERATION_KEY = "split" as const;
-
-export const generateMetadata = buildOperationMetadata(LOCALE, OPERATION_KEY);
-export default buildOperationPage(LOCALE, OPERATION_KEY);

--- a/src/app/(es)/(operations)/extraer/page.tsx
+++ b/src/app/(es)/(operations)/extraer/page.tsx
@@ -1,8 +1,0 @@
-import { buildOperationMetadata, buildOperationPage } from "../../../(helpers)/operation-handlers";
-import { DEFAULT_LOCALE } from "../../../../i18n/config";
-
-const LOCALE = DEFAULT_LOCALE;
-const OPERATION_KEY = "extract" as const;
-
-export const generateMetadata = buildOperationMetadata(LOCALE, OPERATION_KEY);
-export default buildOperationPage(LOCALE, OPERATION_KEY);

--- a/src/app/(es)/(operations)/reordenar/page.tsx
+++ b/src/app/(es)/(operations)/reordenar/page.tsx
@@ -1,8 +1,0 @@
-import { buildOperationMetadata, buildOperationPage } from "../../../(helpers)/operation-handlers";
-import { DEFAULT_LOCALE } from "../../../../i18n/config";
-
-const LOCALE = DEFAULT_LOCALE;
-const OPERATION_KEY = "reorder" as const;
-
-export const generateMetadata = buildOperationMetadata(LOCALE, OPERATION_KEY);
-export default buildOperationPage(LOCALE, OPERATION_KEY);

--- a/src/app/(es)/(operations)/unir/page.tsx
+++ b/src/app/(es)/(operations)/unir/page.tsx
@@ -1,8 +1,0 @@
-import { buildOperationMetadata, buildOperationPage } from "../../../(helpers)/operation-handlers";
-import { DEFAULT_LOCALE } from "../../../../i18n/config";
-
-const LOCALE = DEFAULT_LOCALE;
-const OPERATION_KEY = "merge" as const;
-
-export const generateMetadata = buildOperationMetadata(LOCALE, OPERATION_KEY);
-export default buildOperationPage(LOCALE, OPERATION_KEY);

--- a/src/app/(es)/layout.tsx
+++ b/src/app/(es)/layout.tsx
@@ -14,7 +14,7 @@ import { LocaleProvider } from "../../i18n/LocaleProvider";
 import { SchemaOrg } from "../../components/SchemaOrg";
 import { BreadcrumbSchema } from "../../components/seo/BreadcrumbSchema";
 
-import { METADATA_BASE, SHARED_ICONS, SHARED_OPEN_GRAPH } from "../../lib/metadata-shared";
+import { METADATA_BASE, SHARED_ICONS, SHARED_OPEN_GRAPH, SHARED_TWITTER } from "../../lib/metadata-shared";
 
 export const metadata = {
   metadataBase: METADATA_BASE,
@@ -54,6 +54,7 @@ export const metadata = {
     locale: "es_ES",
     type: "website",
   },
+  twitter: SHARED_TWITTER,
 };
 
 export default async function RootLayout({

--- a/src/app/de/layout.tsx
+++ b/src/app/de/layout.tsx
@@ -11,8 +11,9 @@ import { GaPageViewTracker } from "../../components/analytics/GaPageViewTracker"
 import { WebVitalsReporter } from "../../components/analytics/WebVitalsReporter";
 import CookieBanner from "../../components/CookieBanner";
 import { SchemaOrg } from "../../components/SchemaOrg";
+import { BreadcrumbSchema } from "../../components/seo/BreadcrumbSchema";
 
-import { METADATA_BASE, SHARED_ICONS, SHARED_OPEN_GRAPH } from "../../lib/metadata-shared";
+import { METADATA_BASE, SHARED_ICONS, SHARED_OPEN_GRAPH, SHARED_TWITTER } from "../../lib/metadata-shared";
 
 const LOCALE = "de" as const;
 
@@ -50,6 +51,7 @@ export const metadata = {
     locale: "de_DE",
     type: "website",
   },
+  twitter: SHARED_TWITTER,
 };
 
 export default function DeLayout({ children }: { children: ReactNode }) {
@@ -58,6 +60,7 @@ export default function DeLayout({ children }: { children: ReactNode }) {
       <head>
         <GoogleAnalyticsScripts />
         <SchemaOrg />
+        <BreadcrumbSchema />
       </head>
       <body className={`font-sans ${GeistSans.variable} ${GeistMono.variable}`}>
         <LocaleProvider locale={LOCALE}>

--- a/src/app/en/layout.tsx
+++ b/src/app/en/layout.tsx
@@ -11,8 +11,9 @@ import { GaPageViewTracker } from "../../components/analytics/GaPageViewTracker"
 import { WebVitalsReporter } from "../../components/analytics/WebVitalsReporter";
 import CookieBanner from "../../components/CookieBanner";
 import { SchemaOrg } from "../../components/SchemaOrg";
+import { BreadcrumbSchema } from "../../components/seo/BreadcrumbSchema";
 
-import { METADATA_BASE, SHARED_ICONS, SHARED_OPEN_GRAPH } from "../../lib/metadata-shared";
+import { METADATA_BASE, SHARED_ICONS, SHARED_OPEN_GRAPH, SHARED_TWITTER } from "../../lib/metadata-shared";
 
 const LOCALE = "en" as const;
 
@@ -50,6 +51,7 @@ export const metadata = {
     locale: "en_US",
     type: "website",
   },
+  twitter: SHARED_TWITTER,
 };
 
 export default function EnLayout({ children }: { children: ReactNode }) {
@@ -58,6 +60,7 @@ export default function EnLayout({ children }: { children: ReactNode }) {
       <head>
         <GoogleAnalyticsScripts />
         <SchemaOrg />
+        <BreadcrumbSchema />
       </head>
       <body className={`font-sans ${GeistSans.variable} ${GeistMono.variable}`}>
         <LocaleProvider locale={LOCALE}>

--- a/src/app/fr/layout.tsx
+++ b/src/app/fr/layout.tsx
@@ -11,8 +11,9 @@ import { GaPageViewTracker } from "../../components/analytics/GaPageViewTracker"
 import { WebVitalsReporter } from "../../components/analytics/WebVitalsReporter";
 import CookieBanner from "../../components/CookieBanner";
 import { SchemaOrg } from "../../components/SchemaOrg";
+import { BreadcrumbSchema } from "../../components/seo/BreadcrumbSchema";
 
-import { METADATA_BASE, SHARED_ICONS, SHARED_OPEN_GRAPH } from "../../lib/metadata-shared";
+import { METADATA_BASE, SHARED_ICONS, SHARED_OPEN_GRAPH, SHARED_TWITTER } from "../../lib/metadata-shared";
 
 const LOCALE = "fr" as const;
 
@@ -50,6 +51,7 @@ export const metadata = {
     locale: "fr_FR",
     type: "website",
   },
+  twitter: SHARED_TWITTER,
 };
 
 export default function FrLayout({ children }: { children: ReactNode }) {
@@ -58,6 +60,7 @@ export default function FrLayout({ children }: { children: ReactNode }) {
       <head>
         <GoogleAnalyticsScripts />
         <SchemaOrg />
+        <BreadcrumbSchema />
       </head>
       <body className={`font-sans ${GeistSans.variable} ${GeistMono.variable}`}>
         <LocaleProvider locale={LOCALE}>

--- a/src/app/it/layout.tsx
+++ b/src/app/it/layout.tsx
@@ -11,8 +11,9 @@ import { GaPageViewTracker } from "../../components/analytics/GaPageViewTracker"
 import { WebVitalsReporter } from "../../components/analytics/WebVitalsReporter";
 import CookieBanner from "../../components/CookieBanner";
 import { SchemaOrg } from "../../components/SchemaOrg";
+import { BreadcrumbSchema } from "../../components/seo/BreadcrumbSchema";
 
-import { METADATA_BASE, SHARED_ICONS, SHARED_OPEN_GRAPH } from "../../lib/metadata-shared";
+import { METADATA_BASE, SHARED_ICONS, SHARED_OPEN_GRAPH, SHARED_TWITTER } from "../../lib/metadata-shared";
 
 const LOCALE = "it" as const;
 
@@ -50,6 +51,7 @@ export const metadata = {
     locale: "it_IT",
     type: "website",
   },
+  twitter: SHARED_TWITTER,
 };
 
 export default function ItLayout({ children }: { children: ReactNode }) {
@@ -58,6 +60,7 @@ export default function ItLayout({ children }: { children: ReactNode }) {
       <head>
         <GoogleAnalyticsScripts />
         <SchemaOrg />
+        <BreadcrumbSchema />
       </head>
       <body className={`font-sans ${GeistSans.variable} ${GeistMono.variable}`}>
         <LocaleProvider locale={LOCALE}>

--- a/src/app/pt/layout.tsx
+++ b/src/app/pt/layout.tsx
@@ -11,8 +11,9 @@ import { GaPageViewTracker } from "../../components/analytics/GaPageViewTracker"
 import { WebVitalsReporter } from "../../components/analytics/WebVitalsReporter";
 import CookieBanner from "../../components/CookieBanner";
 import { SchemaOrg } from "../../components/SchemaOrg";
+import { BreadcrumbSchema } from "../../components/seo/BreadcrumbSchema";
 
-import { METADATA_BASE, SHARED_ICONS, SHARED_OPEN_GRAPH } from "../../lib/metadata-shared";
+import { METADATA_BASE, SHARED_ICONS, SHARED_OPEN_GRAPH, SHARED_TWITTER } from "../../lib/metadata-shared";
 
 const LOCALE = "pt" as const;
 
@@ -48,6 +49,7 @@ export const metadata = {
     locale: "pt_BR",
     type: "website",
   },
+  twitter: SHARED_TWITTER,
 };
 
 export default function PtLayout({ children }: { children: ReactNode }) {
@@ -56,6 +58,7 @@ export default function PtLayout({ children }: { children: ReactNode }) {
       <head>
         <GoogleAnalyticsScripts />
         <SchemaOrg />
+        <BreadcrumbSchema />
       </head>
       <body className={`font-sans ${GeistSans.variable} ${GeistMono.variable}`}>
         <LocaleProvider locale={LOCALE}>

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -25,7 +25,9 @@ export default function CookieBanner() {
             if (typeof window !== 'undefined' && (window as unknown as WindowWithGtag).gtag) {
                 (window as unknown as WindowWithGtag).gtag('consent', 'update', {
                     'ad_storage': 'granted',
-                    'analytics_storage': 'granted'
+                    'analytics_storage': 'granted',
+                    'ad_user_data': 'granted',
+                    'ad_personalization': 'granted'
                 });
             }
         }
@@ -39,7 +41,9 @@ export default function CookieBanner() {
         if (typeof window !== 'undefined' && (window as unknown as WindowWithGtag).gtag) {
             (window as unknown as WindowWithGtag).gtag('consent', 'update', {
                 'ad_storage': 'granted',
-                'analytics_storage': 'granted'
+                'analytics_storage': 'granted',
+                'ad_user_data': 'granted',
+                'ad_personalization': 'granted'
             });
         }
     };

--- a/src/components/analytics/GoogleAnalyticsScripts.tsx
+++ b/src/components/analytics/GoogleAnalyticsScripts.tsx
@@ -25,7 +25,9 @@ export function GoogleAnalyticsScripts() {
           
           gtag('consent', 'default', {
             'ad_storage': 'denied',
-            'analytics_storage': 'denied'
+            'analytics_storage': 'denied',
+            'ad_user_data': 'denied',
+            'ad_personalization': 'denied'
           });
 
           gtag('js', new Date());

--- a/src/lib/metadata-shared.ts
+++ b/src/lib/metadata-shared.ts
@@ -17,3 +17,7 @@ export const SHARED_OPEN_GRAPH: Metadata["openGraph"] = {
         }
     ],
 };
+
+export const SHARED_TWITTER: Metadata["twitter"] = {
+    card: "summary_large_image",
+};


### PR DESCRIPTION
- Removed redundant static Spanish operation folders (`comprimir`, `dividir`, `extraer`, `reordenar`, `unir`) to resolve route duplication warnings in Google Search Console (dynamic `[operation]` route now handles all locales).
- Metadata: Added missing Breadcrumb schema tags to all localized layouts (`en`, `de`, `fr`, `it`, `pt`) and implemented global Twitter Card metadata configurations across all layouts.

## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.

Fixes # (issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
