### PR TITLE
feat: implement cookie consent logic to conditionally load Google Analytics and track events only after user opt-in

### DIFF
--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -36,21 +36,25 @@ export default function CookieBanner() {
     const handleAccept = () => {
         localStorage.setItem('cookie_consent', 'true');
         setIsVisible(false);
-
-        // Update GA consent
-        if (typeof window !== 'undefined' && (window as unknown as WindowWithGtag).gtag) {
-            (window as unknown as WindowWithGtag).gtag('consent', 'update', {
-                'ad_storage': 'granted',
-                'analytics_storage': 'granted',
-                'ad_user_data': 'granted',
-                'ad_personalization': 'granted'
-            });
+        if (typeof window !== 'undefined') {
+            window.dispatchEvent(new Event('cookie_consent_changed'));
+            if ((window as unknown as WindowWithGtag).gtag) {
+                (window as unknown as WindowWithGtag).gtag('consent', 'update', {
+                    'ad_storage': 'granted',
+                    'analytics_storage': 'granted',
+                    'ad_user_data': 'granted',
+                    'ad_personalization': 'granted'
+                });
+            }
         }
     };
 
     const handleDecline = () => {
         localStorage.setItem('cookie_consent', 'false');
         setIsVisible(false);
+        if (typeof window !== 'undefined') {
+            window.dispatchEvent(new Event('cookie_consent_changed'));
+        }
     };
 
     if (!isVisible) return null;

--- a/src/components/analytics/GaPageViewTracker.tsx
+++ b/src/components/analytics/GaPageViewTracker.tsx
@@ -3,7 +3,7 @@
 import { useEffect } from 'react';
 import { usePathname, useSearchParams } from 'next/navigation';
 
-const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || (process.env.NODE_ENV !== 'production' ? 'G-MEASUREMENT-ID' : undefined);
 const DEBUG = process.env.NEXT_PUBLIC_ANALYTICS_DEBUG === 'true';
 
 const trackPageview = (url: string) => {
@@ -11,8 +11,12 @@ const trackPageview = (url: string) => {
     return;
   }
 
-  if (typeof window === 'undefined' || typeof window.gtag !== 'function') {
-    if (DEBUG && typeof window !== 'undefined') {
+  if (typeof window === 'undefined' || localStorage.getItem('cookie_consent') !== 'true') {
+    return;
+  }
+
+  if (typeof window.gtag !== 'function') {
+    if (DEBUG) {
       console.debug('[analytics] window.gtag unavailable for pageview', url);
     }
     return;

--- a/src/components/analytics/GoogleAnalyticsScripts.tsx
+++ b/src/components/analytics/GoogleAnalyticsScripts.tsx
@@ -1,12 +1,34 @@
+'use client';
+
+import { useState, useEffect } from 'react';
 import Script from "next/script";
 
-const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || (process.env.NODE_ENV !== 'production' ? 'G-MEASUREMENT-ID' : undefined);
 
 export function GoogleAnalyticsScripts() {
-  if (!GA_MEASUREMENT_ID) {
-    if (process.env.NODE_ENV !== "production") {
-      console.warn("[analytics] NEXT_PUBLIC_GA_MEASUREMENT_ID is not set. Skipping GA script load.");
-    }
+  const [hasConsent, setHasConsent] = useState(false);
+
+  useEffect(() => {
+    const checkConsent = () => {
+      setHasConsent(localStorage.getItem('cookie_consent') === 'true');
+    };
+
+    checkConsent();
+
+    const handleConsentChange = () => {
+      checkConsent();
+    };
+
+    window.addEventListener('cookie_consent_changed', handleConsentChange);
+    window.addEventListener('storage', handleConsentChange);
+
+    return () => {
+      window.removeEventListener('cookie_consent_changed', handleConsentChange);
+      window.removeEventListener('storage', handleConsentChange);
+    };
+  }, []);
+
+  if (!GA_MEASUREMENT_ID || !hasConsent) {
     return null;
   }
 
@@ -23,11 +45,13 @@ export function GoogleAnalyticsScripts() {
           function gtag(){window.dataLayer.push(arguments);}
           window.gtag = window.gtag || gtag;
           
+          // Default consent is set to 'granted' here because this component is only rendered
+          // after explicit user opt-in (cookie_consent === 'true'). GA scripts do not load by default.
           gtag('consent', 'default', {
-            'ad_storage': 'denied',
-            'analytics_storage': 'denied',
-            'ad_user_data': 'denied',
-            'ad_personalization': 'denied'
+            'ad_storage': 'granted',
+            'analytics_storage': 'granted',
+            'ad_user_data': 'granted',
+            'ad_personalization': 'granted'
           });
 
           gtag('js', new Date());
@@ -39,3 +63,4 @@ export function GoogleAnalyticsScripts() {
     </>
   );
 }
+

--- a/src/components/analytics/WebVitalsReporter.tsx
+++ b/src/components/analytics/WebVitalsReporter.tsx
@@ -2,7 +2,7 @@
 
 import { useReportWebVitals } from 'next/web-vitals';
 
-const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || (process.env.NODE_ENV !== 'production' ? 'G-MEASUREMENT-ID' : undefined);
 const DEBUG = process.env.NEXT_PUBLIC_ANALYTICS_DEBUG === 'true';
 
 export function WebVitalsReporter() {
@@ -11,7 +11,7 @@ export function WebVitalsReporter() {
       return;
     }
 
-    if (typeof window === 'undefined') {
+    if (typeof window === 'undefined' || localStorage.getItem('cookie_consent') !== 'true') {
       return;
     }
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,4 +1,4 @@
-const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID;
+const GA_MEASUREMENT_ID = process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || (process.env.NODE_ENV !== 'production' ? 'G-MEASUREMENT-ID' : undefined);
 const DEBUG = process.env.NEXT_PUBLIC_ANALYTICS_DEBUG === 'true';
 
 type TrackEventOptions = {
@@ -15,7 +15,10 @@ declare global {
   }
 }
 
-export const isAnalyticsEnabled = () => Boolean(GA_MEASUREMENT_ID);
+export const isAnalyticsEnabled = () => {
+  if (typeof window === 'undefined') return false;
+  return Boolean(GA_MEASUREMENT_ID) && localStorage.getItem('cookie_consent') === 'true';
+};
 
 export function trackEvent({ action, category, label, value, params }: TrackEventOptions) {
   if (!GA_MEASUREMENT_ID) {
@@ -28,6 +31,13 @@ export function trackEvent({ action, category, label, value, params }: TrackEven
   if (typeof window === 'undefined') {
     if (DEBUG) {
       console.debug('[analytics] trackEvent skipped on server', { action, category, label, value, params });
+    }
+    return;
+  }
+
+  if (localStorage.getItem('cookie_consent') !== 'true') {
+    if (DEBUG) {
+      console.debug('[analytics] trackEvent skipped (analytics not opted-in)', { action, category, label, value, params });
     }
     return;
   }

--- a/tests/e2e/analytics.spec.ts
+++ b/tests/e2e/analytics.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Google Analytics Opt-In', () => {
+    test('Google Analytics scripts are not loaded by default before opt-in', async ({ page }) => {
+        const gaRequests: string[] = [];
+        page.on('request', request => {
+            if (request.url().includes('googletagmanager.com')) {
+                gaRequests.push(request.url());
+            }
+        });
+
+        await page.goto('/');
+        await page.waitForLoadState('domcontentloaded');
+
+        // Check that no request was made to Google Tag Manager
+        expect(gaRequests.length).toBe(0);
+
+        // Check window.gtag is undefined before consent
+        const isGtagDefined = await page.evaluate(() => typeof (window as unknown as { gtag?: unknown }).gtag !== 'undefined');
+        expect(isGtagDefined).toBe(false);
+
+        // Check initial localStorage is null
+        const consent = await page.evaluate(() => localStorage.getItem('cookie_consent'));
+        expect(consent).toBeNull();
+    });
+
+    test('Google Analytics gets enabled when opt-in consent is given', async ({ page }) => {
+        await page.goto('/');
+        await page.waitForLoadState('domcontentloaded');
+
+        // Locate and click the accept button in the Cookie Banner
+        const acceptButton = page.locator('button').filter({ hasText: /aceptar|accept/i }).first();
+        await expect(acceptButton).toBeVisible();
+        await acceptButton.click();
+
+        // Verify cookie_consent is set to 'true' in localStorage
+        const consent = await page.evaluate(() => localStorage.getItem('cookie_consent'));
+        expect(consent).toBe('true');
+
+        // Verify that the GA script tag (#ga-loader) is dynamically inserted into the DOM
+        const gaLoaderExists = await page.evaluate(() => {
+            return document.getElementById('ga-loader') !== null || typeof (window as unknown as { gtag?: unknown }).gtag !== 'undefined';
+        });
+        expect(gaLoaderExists).toBe(true);
+    });
+
+    test('Google Analytics respects existing opt-in consent on page load', async ({ page }) => {
+        // Pre-set cookie consent to 'true'
+        await page.addInitScript(() => {
+            localStorage.setItem('cookie_consent', 'true');
+        });
+
+        await page.goto('/');
+        await page.waitForLoadState('domcontentloaded');
+
+        const consent = await page.evaluate(() => localStorage.getItem('cookie_consent'));
+        expect(consent).toBe('true');
+
+        const gaLoaderExists = await page.evaluate(() => document.getElementById('ga-loader') !== null);
+        expect(gaLoaderExists).toBe(true);
+    });
+});

--- a/tests/e2e/analytics.spec.ts
+++ b/tests/e2e/analytics.spec.ts
@@ -38,10 +38,7 @@ test.describe('Google Analytics Opt-In', () => {
         expect(consent).toBe('true');
 
         // Verify that the GA script tag (#ga-loader) is dynamically inserted into the DOM
-        const gaLoaderExists = await page.evaluate(() => {
-            return document.getElementById('ga-loader') !== null || typeof (window as unknown as { gtag?: unknown }).gtag !== 'undefined';
-        });
-        expect(gaLoaderExists).toBe(true);
+        await expect(page.locator('#ga-loader')).toBeAttached();
     });
 
     test('Google Analytics respects existing opt-in consent on page load', async ({ page }) => {
@@ -56,7 +53,7 @@ test.describe('Google Analytics Opt-In', () => {
         const consent = await page.evaluate(() => localStorage.getItem('cookie_consent'));
         expect(consent).toBe('true');
 
-        const gaLoaderExists = await page.evaluate(() => document.getElementById('ga-loader') !== null);
-        expect(gaLoaderExists).toBe(true);
+        await expect(page.locator('#ga-loader')).toBeAttached();
     });
 });
+


### PR DESCRIPTION
## Description

GA should be loaded only after cookie banner opt-in gets accepted.

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

- Playwright tests (using a fake "G-MEASUREMENT-ID" GA identifier).